### PR TITLE
Add Terraform Init usage to example

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Currently supported Terraform commands:
 
 ### Installation
 Navigate the the Golang project that this package will be used in. This package can be installed using the Go package manager.
+
 `go get github.com/kmoe/terraform-exec`
 
 ### Example

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Currently supported Terraform commands:
 * show
 
 ### Installation
-Navigate to your Golang project in the Terminal, then retrieve the package.
+Navigate the the Golang project that this package will be used in. This package can be installed using the Go package manager.
 `go get github.com/kmoe/terraform-exec`
 
 ### Example

--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ Currently supported Terraform commands:
 * init
 * show
 
+### Installation
+Navigate to your Golang project in the Terminal, then retrieve the package.
+`go get github.com/kmoe/terraform-exec`
+
 ### Example
 
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # terraform-exec
-
 A Go module for constructing and running [Terraform](https://terraform.io) CLI commands. Structured return values use the data types defined in [terraform-json](https://github.com/hashicorp/terraform-json).
 
 The [Terraform Plugin SDK](https://github.com/hashicorp/terraform-plugin-sdk) is the canonical Go interface for Terraform plugins using the gRPC protocol. This library is intended for use in Go programs that make use of Terraform's other interface, the CLI. Importing this library is preferable to importing `github.com/hashicorp/terraform/command`, because the latter is not intended for use outside Terraform Core.
@@ -12,6 +11,9 @@ Top-level Terraform commands each have their own function, which will return eit
 
 Convenience functions are provided for obtaining a raw `exec.Cmd` or command-line `string` for each supported Terraform command.
 
+Currently supported Terraform commands:
+* init
+* show
 
 ### Example
 
@@ -20,20 +22,33 @@ Convenience functions are provided for obtaining a raw `exec.Cmd` or command-lin
 package main
 
 import (
-    tfexec "github.com/kmoe/terraform-exec"
-    
-func main() {
-    workingDir := "/path/to/working/dir"
+        "fmt"
+        "os"
 
-    state, err := tfexec.Show(workingDir)
-    if err != nil {
-        panic(err)
-    }
-    
-    fmt.Println(state.FormatVersion) // "0.1"
+        tfexec "github.com/kmoe/terraform-exec"
 )
-```
 
+func main() {
+        workingDir := os.Getenv("GOPATH") + "/src/github.com/kmoe/terraform-exec/testdata"
+
+        // Run `terraform init` so that the working directories state can be initialized.
+        err := tfexec.Init(workingDir)
+        if err != nil {
+                panic(err)
+        }
+
+        // Run `terraform show` against the state defined in the working directory.
+        state, err := tfexec.Show(workingDir)
+        if err != nil {
+                panic(err)
+        }
+
+        // Print all returned values from the `terraform show` command (of type *tfjson.State)
+        fmt.Println(state.FormatVersion) // "0.1"
+        fmt.Println(state.TerraformVersion)
+        fmt.Println(state.Values)
+}
+```
 
 ### `Init(workingDir string, args ...string) error`
 


### PR DESCRIPTION
Allow for developers to get started with this library:
- Fix some syntax updates in the README.md code snippet.
- Modify the example to show usage of `terraform init`.
- Self-reference the `testdata` directory as the Terraform project, so the code works out of the box.


