### PR TITLE
CI and release process

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,130 @@
+version: 2.1
+
+orbs:
+  win: circleci/windows@2.2.0
+
+commands:
+  go_build:
+    steps:
+      - run: go build ./...
+  go_test:
+    steps:
+      - run: go test -v ./...
+
+jobs:
+  winbuild:
+    executor:
+      name: win/default
+    steps:
+      - checkout
+      - go_build
+  wintest:
+    executor:
+      name: win/default
+    steps:
+      - checkout
+      - go_test
+
+  "go112_build":
+    docker:
+      - image: circleci/golang:1.12
+    steps:
+      - checkout
+      - go_build
+  "go112_test":
+    docker:
+      - image: circleci/golang:1.12
+    steps:
+      - checkout
+      - go_build
+
+  "go114_build":
+    docker:
+      - image: circleci/golang:1.14
+    steps:
+      - checkout
+      - go_build
+  "go114_test":
+    docker:
+      - image: circleci/golang:1.14
+    parameters:
+      test_results:
+        type: string
+        default: /tmp/test-results
+    steps:
+      - checkout
+      - go_test
+  "go114_vet":
+    docker:
+      - image: circleci/golang:1.14
+    steps:
+      - checkout
+      - run: go vet ./...
+  "go114_fmt":
+    docker:
+      - image: circleci/golang:1.14
+    steps:
+      - checkout
+      - run: gofmt -s -l .
+  "go114_release":
+    docker:
+      - image: circleci/golang:1.14
+    steps:
+      - add_ssh_keys:
+          fingerprints:
+            - "db:cf:97:b8:d6:ac:86:74:96:e1:54:e4:bc:27:2b:d0"
+      - checkout
+      - run: ./scripts/release/release.sh
+
+workflows:
+  version: 2
+  pr:
+    jobs:
+      - winbuild
+      - wintest
+      - "go112_build"
+      - "go112_test"
+      - "go114_build"
+      - "go114_test":
+          requires:
+            - "go114_build"
+      - "go114_vet":
+          requires:
+            - "go114_build"
+      - "go114_fmt":
+          requires:
+            - "go114_build"
+  release:
+    jobs:
+      - winbuild
+      - wintest
+      - "go112_build"
+      - "go112_test"
+      - "go114_build"
+      - "go114_test":
+          requires:
+            - "go114_build"
+      - "go114_vet":
+          requires:
+            - "go114_build"
+      - "go114_fmt":
+          requires:
+            - "go114_build"
+      - trigger-release:
+          filters:
+            branches:
+              only:
+                - master
+          type: approval
+      - "go114_release":
+          filters:
+            branches:
+              only:
+                - master
+          requires:
+            - trigger-release
+            - "go114_test"
+            - "go114_vet"
+            - "go114_fmt"
+            - winbuild
+            - wintest

--- a/scripts/release/changelog_links.sh
+++ b/scripts/release/changelog_links.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# This script rewrites [GH-nnnn]-style references in the CHANGELOG.md file to
+# be Markdown links to the given github issues.
+#
+# This is run during releases so that the issue references in all of the
+# released items are presented as clickable links, but we can just use the
+# easy [GH-nnnn] shorthand for quickly adding items to the "Unrelease" section
+# while merging things between releases.
+
+set -e
+
+if [[ ! -f CHANGELOG.md ]]; then
+    echo "ERROR: CHANGELOG.md not found in pwd."
+    echo "Please run this from the root of the repository"
+    exit 1
+fi
+
+if [[ `uname` == "Darwin" ]]; then
+    echo "Using BSD sed"
+    SED="sed -i.bak -E -e"
+else
+    echo "Using GNU sed"
+    SED="sed -i.bak -r -e"
+fi
+
+$SED 's/GH-([0-9]+)/\[#\1\]\(https:\/\/github.com\/hashicorp\/terraform-plugin-sdk\/issues\/\1\)/g' -e 's/\[\[#(.+)([0-9])\)]$/(\[#\1\2))/g' CHANGELOG.md
+
+rm CHANGELOG.md.bak

--- a/scripts/release/release.sh
+++ b/scripts/release/release.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+
+set -e
+set -x
+
+# release.sh will:
+# 1. Modify changelog
+# 2. Run changelog links script
+# 3. Modify version in tfinstall/version.go
+# 4. Commit and push changes
+# 5. Create a Git tag
+
+function pleaseUseGNUsed {
+    echo "Please install GNU sed to your PATH as 'sed'."
+    exit 1
+}
+
+function init {
+  sed --version > /dev/null || pleaseUseGNUsed
+
+  DATE=`date '+%B %d, %Y'`
+  START_DIR=`pwd`
+
+  if [ "$CI" = true ] ; then
+    GPG_KEY_ID=C6DC8F8C8E78B36A
+    gpg --batch --import <(echo -e "${GPG_PUBLIC_KEY}")
+    gpg --batch --import <(echo -e "${GPG_PRIVATE_KEY}")
+    git config --global user.email hashibot-feedback+tf-sdk-circleci@hashicorp.com
+    git config --global user.name "Terraform SDK CircleCI"
+  fi
+
+  TARGET_VERSION="$(getTargetVersion)"
+}
+
+semverRegex='\([0-9]\+\.[0-9]\+\.[0-9]\+\)\(-\?\)\([0-9a-zA-Z.]\+\)\?'
+
+function getTargetVersion {
+  # parse target version from CHANGELOG
+  sed -n 's/^# '"$semverRegex"' (Unreleased)$/\1\2\3/p' CHANGELOG.md || \
+     (echo "\nTarget version not found in changelog, exiting" && \
+       exit 1)
+}
+
+function modifyChangelog {
+  sed -i "s/$TARGET_VERSION (Unreleased)$/$TARGET_VERSION ($DATE)/" CHANGELOG.md
+}
+
+function changelogLinks {
+  ./scripts/release/changelog_links.sh
+}
+
+function changelogMain {
+  printf "Modifying Changelog..."
+  modifyChangelog
+  printf "ok!\n"
+  printf "Running Changelog Links..."
+  changelogLinks
+  printf "ok!\n"
+}
+
+function modifyVersionFiles {
+  sed -i "s/const Version =.*/const Version = \"${TARGET_VERSION}\"/" tfinstall/version.go
+}
+
+function commitChanges {
+  git add CHANGELOG.md
+  modifyVersionFiles
+  git add tfinstall/version.go
+
+  if [ "$CI" = true ] ; then
+      git commit --gpg-sign="${GPG_KEY_ID}" -m "v${TARGET_VERSION} [skip ci]"
+      git tag -a -m "v${TARGET_VERSION}" -s -u "${GPG_KEY_ID}" "v${TARGET_VERSION}"
+  else
+      git commit -m "v${TARGET_VERSION} [skip ci]"
+      git tag -a -m "v${TARGET_VERSION}" -s "v${TARGET_VERSION}"
+  fi
+
+  git push origin "${CIRCLE_BRANCH}"
+  git push origin "v${TARGET_VERSION}"
+}
+
+function commitMain {
+  printf "Committing Changes..."
+  commitChanges
+  printf "ok!\n"
+}
+
+function main {
+  init
+  changelogMain
+  commitMain
+}
+
+main


### PR DESCRIPTION
fixes #11 

Based on the SDK CircleCI setup.

### PR builds

On each PR, a matrix of builds is run:
- build and test with Go 1.12
- build and test with Go 1.14
- gofmt and go vet checks (Go 1.14)
- build and test on Windows

There is a macOS executor on CircleCI, but it doesn't have Go installed, and the architecture is sufficiently similar to Linux to leave this out for now. If we want to test all PRs on macOS we can add this later.

### Release builds

As in the SDK, to release from `master` one needs only to update CHANGELOG.md to include a `#x.y.z (Unreleased)` line and then trigger the `trigger_release` build.

The release workflow will then:
 - run all build and test jobs as above
 - format the changelog
 - modify the version in `tfinstall/version.go` (this will be removed in https://github.com/hashicorp/terraform-exec/issues/22)
 - commit and push changes as a bot user
 - tag the version

Git commits and tags are signed using the bot's GPG key.

The release workflow was tested by temporarily adding `ci-release` to its allowed branches, preparing the branch for a v0.0.1 release, and verifying the changes committed and pushed to this branch by the bot.