### PR TITLE
implement Import

### DIFF
--- a/tfexec/terraform.go
+++ b/tfexec/terraform.go
@@ -498,6 +498,20 @@ func (opt *VarFileOption) configureImport(conf *importConfig) {
 	conf.varFile = opt.path
 }
 
+func (t *Terraform) Import(ctx context.Context, opts ...ImportOption) error {
+	importCmd := t.ImportCmd(ctx, opts...)
+
+	var errBuf strings.Builder
+	importCmd.Stderr = &errBuf
+
+	err := importCmd.Run()
+	if err != nil {
+		return parseError(errBuf.String())
+	}
+
+	return nil
+}
+
 type outputConfig struct {
 	state string
 	json  bool


### PR DESCRIPTION
`Import()` had been missed out of the public API by mistake. Currently we only test the `*Cmd` versions of these functions, so until #19 is implemented this will remain untested.