### PR TITLE
Stop exporting exec.Cmd versions of methods

### DIFF
--- a/tfexec/apply.go
+++ b/tfexec/apply.go
@@ -81,7 +81,7 @@ func (opt *DirOrPlanOption) configureApply(conf *applyConfig) {
 }
 
 func (tf *Terraform) Apply(ctx context.Context, opts ...ApplyOption) error {
-	applyCmd := tf.ApplyCmd(ctx, opts...)
+	applyCmd := tf.applyCmd(ctx, opts...)
 
 	var errBuf strings.Builder
 	applyCmd.Stderr = &errBuf
@@ -94,7 +94,7 @@ func (tf *Terraform) Apply(ctx context.Context, opts ...ApplyOption) error {
 	return nil
 }
 
-func (tf *Terraform) ApplyCmd(ctx context.Context, opts ...ApplyOption) *exec.Cmd {
+func (tf *Terraform) applyCmd(ctx context.Context, opts ...ApplyOption) *exec.Cmd {
 	c := defaultApplyOptions
 
 	for _, o := range opts {

--- a/tfexec/apply_test.go
+++ b/tfexec/apply_test.go
@@ -42,7 +42,7 @@ func TestApplyCmd(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	applyCmd := tf.ApplyCmd(context.Background(), Backup("testbackup"), LockTimeout("200s"), State("teststate"), StateOut("teststateout"), VarFile("testvarfile"), Lock(false), Parallelism(99), Refresh(false), Target("target1"), Target("target2"), Var("var1=foo"), Var("var2=bar"), DirOrPlan("testfile"))
+	applyCmd := tf.applyCmd(context.Background(), Backup("testbackup"), LockTimeout("200s"), State("teststate"), StateOut("teststateout"), VarFile("testvarfile"), Lock(false), Parallelism(99), Refresh(false), Target("target1"), Target("target2"), Var("var1=foo"), Var("var2=bar"), DirOrPlan("testfile"))
 
 	actual := strings.TrimPrefix(cmdString(applyCmd), applyCmd.Path+" ")
 

--- a/tfexec/destroy.go
+++ b/tfexec/destroy.go
@@ -77,7 +77,7 @@ func (opt *VarOption) configureDestroy(conf *destroyConfig) {
 }
 
 func (tf *Terraform) Destroy(ctx context.Context, opts ...DestroyOption) error {
-	destroyCmd := tf.DestroyCmd(ctx, opts...)
+	destroyCmd := tf.destroyCmd(ctx, opts...)
 
 	var errBuf strings.Builder
 	destroyCmd.Stderr = &errBuf
@@ -90,7 +90,7 @@ func (tf *Terraform) Destroy(ctx context.Context, opts ...DestroyOption) error {
 	return nil
 }
 
-func (tf *Terraform) DestroyCmd(ctx context.Context, opts ...DestroyOption) *exec.Cmd {
+func (tf *Terraform) destroyCmd(ctx context.Context, opts ...DestroyOption) *exec.Cmd {
 	c := defaultDestroyOptions
 
 	for _, o := range opts {

--- a/tfexec/destroy_test.go
+++ b/tfexec/destroy_test.go
@@ -17,7 +17,7 @@ func TestDestroyCmd(t *testing.T) {
 	}
 
 	// defaults
-	destroyCmd := tf.DestroyCmd(context.Background())
+	destroyCmd := tf.destroyCmd(context.Background())
 
 	actual := strings.TrimPrefix(cmdString(destroyCmd), destroyCmd.Path+" ")
 
@@ -28,7 +28,7 @@ func TestDestroyCmd(t *testing.T) {
 	}
 
 	// override all defaults
-	destroyCmd = tf.DestroyCmd(context.Background(), Backup("testbackup"), LockTimeout("200s"), State("teststate"), StateOut("teststateout"), VarFile("testvarfile"), Lock(false), Parallelism(99), Refresh(false), Target("target1"), Target("target2"), Var("var1=foo"), Var("var2=bar"))
+	destroyCmd = tf.destroyCmd(context.Background(), Backup("testbackup"), LockTimeout("200s"), State("teststate"), StateOut("teststateout"), VarFile("testvarfile"), Lock(false), Parallelism(99), Refresh(false), Target("target1"), Target("target2"), Var("var1=foo"), Var("var2=bar"))
 
 	actual = strings.TrimPrefix(cmdString(destroyCmd), destroyCmd.Path+" ")
 

--- a/tfexec/import.go
+++ b/tfexec/import.go
@@ -68,7 +68,7 @@ func (opt *VarFileOption) configureImport(conf *importConfig) {
 }
 
 func (t *Terraform) Import(ctx context.Context, address, id string, opts ...ImportOption) error {
-	importCmd := t.ImportCmd(ctx, address, id, opts...)
+	importCmd := t.importCmd(ctx, address, id, opts...)
 
 	var errBuf strings.Builder
 	importCmd.Stderr = &errBuf
@@ -81,7 +81,7 @@ func (t *Terraform) Import(ctx context.Context, address, id string, opts ...Impo
 	return nil
 }
 
-func (tf *Terraform) ImportCmd(ctx context.Context, address, id string, opts ...ImportOption) *exec.Cmd {
+func (tf *Terraform) importCmd(ctx context.Context, address, id string, opts ...ImportOption) *exec.Cmd {
 	c := defaultImportOptions
 
 	for _, o := range opts {

--- a/tfexec/import_test.go
+++ b/tfexec/import_test.go
@@ -86,7 +86,7 @@ func TestImportCmd(t *testing.T) {
 	}
 
 	// defaults
-	importCmd := tf.ImportCmd(context.Background(), "my-addr", "my-id")
+	importCmd := tf.importCmd(context.Background(), "my-addr", "my-id")
 
 	actual := strings.TrimPrefix(cmdString(importCmd), importCmd.Path+" ")
 
@@ -97,7 +97,7 @@ func TestImportCmd(t *testing.T) {
 	}
 
 	// override all defaults
-	importCmd = tf.ImportCmd(context.Background(), "my-addr2", "my-id2",
+	importCmd = tf.importCmd(context.Background(), "my-addr2", "my-id2",
 		Backup("testbackup"),
 		LockTimeout("200s"),
 		State("teststate"),

--- a/tfexec/init.go
+++ b/tfexec/init.go
@@ -83,7 +83,7 @@ func (opt *VerifyPluginsOption) configureInit(conf *initConfig) {
 }
 
 func (t *Terraform) Init(ctx context.Context, opts ...InitOption) error {
-	initCmd := t.InitCmd(ctx, opts...)
+	initCmd := t.initCmd(ctx, opts...)
 
 	var errBuf strings.Builder
 	initCmd.Stderr = &errBuf
@@ -96,7 +96,7 @@ func (t *Terraform) Init(ctx context.Context, opts ...InitOption) error {
 	return nil
 }
 
-func (tf *Terraform) InitCmd(ctx context.Context, opts ...InitOption) *exec.Cmd {
+func (tf *Terraform) initCmd(ctx context.Context, opts ...InitOption) *exec.Cmd {
 	c := defaultInitOptions
 
 	for _, o := range opts {

--- a/tfexec/init_test.go
+++ b/tfexec/init_test.go
@@ -17,7 +17,7 @@ func TestInitCmd(t *testing.T) {
 	}
 
 	// defaults
-	initCmd := tf.InitCmd(context.Background())
+	initCmd := tf.initCmd(context.Background())
 
 	actual := strings.TrimPrefix(cmdString(initCmd), initCmd.Path+" ")
 
@@ -28,7 +28,7 @@ func TestInitCmd(t *testing.T) {
 	}
 
 	// override all defaults
-	initCmd = tf.InitCmd(context.Background(), Backend(false), BackendConfig("confpath1"), BackendConfig("confpath2"), FromModule("testsource"), Get(false), GetPlugins(false), Lock(false), LockTimeout("999s"), PluginDir("testdir1"), PluginDir("testdir2"), Reconfigure(true), Upgrade(true), VerifyPlugins(false))
+	initCmd = tf.initCmd(context.Background(), Backend(false), BackendConfig("confpath1"), BackendConfig("confpath2"), FromModule("testsource"), Get(false), GetPlugins(false), Lock(false), LockTimeout("999s"), PluginDir("testdir1"), PluginDir("testdir2"), Reconfigure(true), Upgrade(true), VerifyPlugins(false))
 
 	actual = strings.TrimPrefix(cmdString(initCmd), initCmd.Path+" ")
 

--- a/tfexec/output.go
+++ b/tfexec/output.go
@@ -34,7 +34,7 @@ type OutputMeta struct {
 }
 
 func (tf *Terraform) Output(ctx context.Context, opts ...OutputOption) (map[string]OutputMeta, error) {
-	outputCmd := tf.OutputCmd(ctx, opts...)
+	outputCmd := tf.outputCmd(ctx, opts...)
 
 	var errBuf strings.Builder
 	var outBuf bytes.Buffer
@@ -57,7 +57,7 @@ func (tf *Terraform) Output(ctx context.Context, opts ...OutputOption) (map[stri
 	return outputs, nil
 }
 
-func (tf *Terraform) OutputCmd(ctx context.Context, opts ...OutputOption) *exec.Cmd {
+func (tf *Terraform) outputCmd(ctx context.Context, opts ...OutputOption) *exec.Cmd {
 	c := defaultOutputOptions
 
 	for _, o := range opts {

--- a/tfexec/output_test.go
+++ b/tfexec/output_test.go
@@ -17,7 +17,7 @@ func TestOutputCmd(t *testing.T) {
 	}
 
 	// defaults
-	outputCmd := tf.OutputCmd(context.Background())
+	outputCmd := tf.outputCmd(context.Background())
 
 	actual := strings.TrimPrefix(cmdString(outputCmd), outputCmd.Path+" ")
 
@@ -28,7 +28,7 @@ func TestOutputCmd(t *testing.T) {
 	}
 
 	// override all defaults
-	outputCmd = tf.OutputCmd(context.Background(),
+	outputCmd = tf.outputCmd(context.Background(),
 		State("teststate"))
 
 	actual = strings.TrimPrefix(cmdString(outputCmd), outputCmd.Path+" ")

--- a/tfexec/plan.go
+++ b/tfexec/plan.go
@@ -74,7 +74,7 @@ func (opt *DestroyFlagOption) configurePlan(conf *planConfig) {
 }
 
 func (tf *Terraform) Plan(ctx context.Context, opts ...PlanOption) error {
-	planCmd := tf.PlanCmd(ctx, opts...)
+	planCmd := tf.planCmd(ctx, opts...)
 
 	var errBuf strings.Builder
 	planCmd.Stderr = &errBuf
@@ -87,7 +87,7 @@ func (tf *Terraform) Plan(ctx context.Context, opts ...PlanOption) error {
 	return nil
 }
 
-func (tf *Terraform) PlanCmd(ctx context.Context, opts ...PlanOption) *exec.Cmd {
+func (tf *Terraform) planCmd(ctx context.Context, opts ...PlanOption) *exec.Cmd {
 	c := defaultPlanOptions
 
 	for _, o := range opts {

--- a/tfexec/plan_test.go
+++ b/tfexec/plan_test.go
@@ -17,7 +17,7 @@ func TestPlanCmd(t *testing.T) {
 	}
 
 	// defaults
-	planCmd := tf.PlanCmd(context.Background())
+	planCmd := tf.planCmd(context.Background())
 
 	actual := strings.TrimPrefix(cmdString(planCmd), planCmd.Path+" ")
 
@@ -28,7 +28,7 @@ func TestPlanCmd(t *testing.T) {
 	}
 
 	// override all defaults
-	planCmd = tf.PlanCmd(context.Background(), Destroy(true), Lock(false), LockTimeout("22s"), Out("whale"), Parallelism(42), Refresh(false), State("marvin"), Target("zaphod"), Target("beeblebrox"), Var("android=paranoid"), Var("brain_size=planet"), VarFile("trillian"))
+	planCmd = tf.planCmd(context.Background(), Destroy(true), Lock(false), LockTimeout("22s"), Out("whale"), Parallelism(42), Refresh(false), State("marvin"), Target("zaphod"), Target("beeblebrox"), Var("android=paranoid"), Var("brain_size=planet"), VarFile("trillian"))
 
 	actual = strings.TrimPrefix(cmdString(planCmd), planCmd.Path+" ")
 

--- a/tfexec/providers_schema.go
+++ b/tfexec/providers_schema.go
@@ -16,7 +16,7 @@ func (tf *Terraform) ProvidersSchema(ctx context.Context) (*tfjson.ProviderSchem
 	var errBuf strings.Builder
 	var outBuf bytes.Buffer
 
-	schemaCmd := tf.ProvidersSchemaCmd(ctx)
+	schemaCmd := tf.providersSchemaCmd(ctx)
 
 	schemaCmd.Stderr = &errBuf
 	schemaCmd.Stdout = &outBuf
@@ -39,7 +39,7 @@ func (tf *Terraform) ProvidersSchema(ctx context.Context) (*tfjson.ProviderSchem
 	return &ret, nil
 }
 
-func (tf *Terraform) ProvidersSchemaCmd(ctx context.Context, args ...string) *exec.Cmd {
+func (tf *Terraform) providersSchemaCmd(ctx context.Context, args ...string) *exec.Cmd {
 	allArgs := []string{"providers", "schema", "-json", "-no-color"}
 	allArgs = append(allArgs, args...)
 

--- a/tfexec/providers_schema_test.go
+++ b/tfexec/providers_schema_test.go
@@ -17,7 +17,7 @@ func TestProvidersSchemaCmd(t *testing.T) {
 	}
 
 	// defaults
-	schemaCmd := tf.ProvidersSchemaCmd(context.Background())
+	schemaCmd := tf.providersSchemaCmd(context.Background())
 
 	actual := strings.TrimPrefix(cmdString(schemaCmd), schemaCmd.Path+" ")
 

--- a/tfexec/show.go
+++ b/tfexec/show.go
@@ -16,7 +16,7 @@ func (tf *Terraform) StateShow(ctx context.Context) (*tfjson.State, error) {
 	var errBuf strings.Builder
 	var outBuf bytes.Buffer
 
-	showCmd := tf.StateShowCmd(ctx)
+	showCmd := tf.stateShowCmd(ctx)
 
 	showCmd.Stderr = &errBuf
 	showCmd.Stdout = &outBuf
@@ -39,7 +39,7 @@ func (tf *Terraform) StateShow(ctx context.Context) (*tfjson.State, error) {
 	return &ret, nil
 }
 
-func (tf *Terraform) StateShowCmd(ctx context.Context, args ...string) *exec.Cmd {
+func (tf *Terraform) stateShowCmd(ctx context.Context, args ...string) *exec.Cmd {
 	allArgs := []string{"show", "-json", "-no-color"}
 	allArgs = append(allArgs, args...)
 

--- a/tfexec/show_test.go
+++ b/tfexec/show_test.go
@@ -94,7 +94,7 @@ func TestStateShowCmd(t *testing.T) {
 	}
 
 	// defaults
-	showCmd := tf.StateShowCmd(context.Background())
+	showCmd := tf.stateShowCmd(context.Background())
 
 	actual := strings.TrimPrefix(cmdString(showCmd), showCmd.Path+" ")
 

--- a/tfexec/terraform_test.go
+++ b/tfexec/terraform_test.go
@@ -44,7 +44,7 @@ func TestCheckpointDisablePropagation(t *testing.T) {
 	tf.SetEnv(map[string]string{
 		"FOOBAR": "1",
 	})
-	initCmd := tf.InitCmd(context.Background())
+	initCmd := tf.initCmd(context.Background())
 	expected := []string{"FOOBAR=1", "CHECKPOINT_DISABLE=1", "TF_LOG="}
 	actual := initCmd.Env
 
@@ -57,7 +57,7 @@ func TestCheckpointDisablePropagation(t *testing.T) {
 		"CHECKPOINT_DISABLE": "",
 		"FOOBAR":             "1",
 	})
-	initCmd = tf.InitCmd(context.Background())
+	initCmd = tf.initCmd(context.Background())
 	expected = []string{"CHECKPOINT_DISABLE=", "FOOBAR=1", "TF_LOG="}
 	actual = initCmd.Env
 


### PR DESCRIPTION
We should only export the methods that execute commands to force all compatibility needs through the controlled interfaces (options, etc), as opposed to letting consumers further customize things like environment. This defeats the purpose of having a canonical testing interface for programmatic CLI invocation.

(per the RFC discussion)

This is based on #23 