### PR TITLE
Clean up error handling for non-ExitError cases

### DIFF
--- a/tfexec/apply.go
+++ b/tfexec/apply.go
@@ -88,7 +88,7 @@ func (tf *Terraform) Apply(ctx context.Context, opts ...ApplyOption) error {
 
 	err := applyCmd.Run()
 	if err != nil {
-		return parseError(errBuf.String())
+		return parseError(err, errBuf.String())
 	}
 
 	return nil

--- a/tfexec/destroy.go
+++ b/tfexec/destroy.go
@@ -84,7 +84,7 @@ func (tf *Terraform) Destroy(ctx context.Context, opts ...DestroyOption) error {
 
 	err := destroyCmd.Run()
 	if err != nil {
-		return parseError(errBuf.String())
+		return parseError(err, errBuf.String())
 	}
 
 	return nil

--- a/tfexec/e2etest/errors_test.go
+++ b/tfexec/e2etest/errors_test.go
@@ -1,0 +1,43 @@
+// This file contains tests that only compile/work in Go 1.13 and forward
+// +build go1.13
+
+package e2etest
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-exec/tfexec/internal/testutil"
+)
+
+func TestUnparsedError(t *testing.T) {
+	// This simulates an unparsed error from the Cmd.Run method (in this case file not found). This
+	// is to ensure we don't miss raising unexpected errors in addition to parsed / well known ones.
+	for _, tfv := range []string{
+		testutil.Latest011,
+		testutil.Latest012,
+		testutil.Latest013,
+	} {
+		t.Run(tfv, func(t *testing.T) {
+			tf, cleanup := setupFixture(t, tfv, "")
+			defer cleanup()
+
+			// force delete the working dir to cause an os.PathError
+			err := os.RemoveAll(tf.WorkingDir())
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			err = tf.Init(context.Background())
+			if err == nil {
+				t.Fatalf("expected error running Init, none returned")
+			}
+			var e *os.PathError
+			if !errors.As(err, &e) {
+				t.Fatalf("expected os.PathError, got %T, %s", err, err)
+			}
+		})
+	}
+}

--- a/tfexec/import.go
+++ b/tfexec/import.go
@@ -75,7 +75,7 @@ func (t *Terraform) Import(ctx context.Context, address, id string, opts ...Impo
 
 	err := importCmd.Run()
 	if err != nil {
-		return parseError(errBuf.String())
+		return parseError(err, errBuf.String())
 	}
 
 	return nil

--- a/tfexec/init.go
+++ b/tfexec/init.go
@@ -90,7 +90,7 @@ func (t *Terraform) Init(ctx context.Context, opts ...InitOption) error {
 
 	err := initCmd.Run()
 	if err != nil {
-		return parseError(errBuf.String())
+		return parseError(err, errBuf.String())
 	}
 
 	return nil

--- a/tfexec/output.go
+++ b/tfexec/output.go
@@ -46,7 +46,7 @@ func (tf *Terraform) Output(ctx context.Context, opts ...OutputOption) (map[stri
 
 	err := outputCmd.Run()
 	if err != nil {
-		return nil, parseError(err.Error())
+		return nil, parseError(err, errBuf.String())
 	}
 
 	err = json.Unmarshal(outBuf.Bytes(), &outputs)

--- a/tfexec/plan.go
+++ b/tfexec/plan.go
@@ -81,7 +81,7 @@ func (tf *Terraform) Plan(ctx context.Context, opts ...PlanOption) error {
 
 	err := planCmd.Run()
 	if err != nil {
-		return parseError(errBuf.String())
+		return parseError(err, errBuf.String())
 	}
 
 	return nil

--- a/tfexec/providers_schema.go
+++ b/tfexec/providers_schema.go
@@ -23,7 +23,7 @@ func (tf *Terraform) ProvidersSchema(ctx context.Context) (*tfjson.ProviderSchem
 
 	err := schemaCmd.Run()
 	if err != nil {
-		return nil, parseError(errBuf.String())
+		return nil, parseError(err, errBuf.String())
 	}
 
 	err = json.Unmarshal(outBuf.Bytes(), &ret)

--- a/tfexec/show.go
+++ b/tfexec/show.go
@@ -23,7 +23,7 @@ func (tf *Terraform) Show(ctx context.Context) (*tfjson.State, error) {
 
 	err := showCmd.Run()
 	if err != nil {
-		return nil, parseError(errBuf.String())
+		return nil, parseError(err, errBuf.String())
 	}
 
 	err = json.Unmarshal(outBuf.Bytes(), &ret)

--- a/tfexec/terraform.go
+++ b/tfexec/terraform.go
@@ -86,3 +86,8 @@ func (tf *Terraform) SetLogPath(path string) error {
 func (tf *Terraform) WorkingDir() string {
 	return tf.workingDir
 }
+
+// ExecPath returns the path to the Terraform executable.
+func (tf *Terraform) ExecPath() string {
+	return tf.execPath
+}

--- a/tfexec/version.go
+++ b/tfexec/version.go
@@ -40,8 +40,7 @@ func (tf *Terraform) version(ctx context.Context) (*version.Version, map[string]
 
 	err := versionCmd.Run()
 	if err != nil {
-		fmt.Println(errBuf.String())
-		return nil, nil, fmt.Errorf("unable to run version command: %w, %s", err, errBuf.String())
+		return nil, nil, parseError(err, errBuf.String())
 	}
 
 	tfVersion, providerVersions, err := parseVersionOutput(outBuf.String())


### PR DESCRIPTION
Note, this is a PR to the `end-to-end-testing` branch, but that can merge first if preferred.