### PR TITLE
tolerate reversed version output

### DIFF
--- a/tfexec/version.go
+++ b/tfexec/version.go
@@ -63,7 +63,7 @@ func (tf *Terraform) version(ctx context.Context) (*version.Version, map[string]
 var (
 	simpleVersionRe = `v?(?P<version>[0-9]+(?:\.[0-9]+)*(?:-[A-Za-z0-9\.]+)?)`
 
-	versionOutputRe         = regexp.MustCompile(`^Terraform ` + simpleVersionRe)
+	versionOutputRe         = regexp.MustCompile(`Terraform ` + simpleVersionRe)
 	providerVersionOutputRe = regexp.MustCompile(`(\n\+ provider[\. ](?P<name>\S+) ` + simpleVersionRe + `)`)
 )
 
@@ -84,7 +84,7 @@ func parseVersionOutput(stdout string) (*version.Version, map[string]*version.Ve
 
 	for _, submatches := range allSubmatches {
 		if len(submatches) != 4 {
-			return nil, nil, fmt.Errorf("unexpected number of providerion version matches %d for %s", len(submatches), stdout)
+			return nil, nil, fmt.Errorf("unexpected number of provider version matches %d for %s", len(submatches), stdout)
 		}
 
 		v, err := version.NewVersion(submatches[3])

--- a/tfinstall/tfinstall.go
+++ b/tfinstall/tfinstall.go
@@ -279,7 +279,8 @@ func runTerraformVersion(execPath string) error {
 		return err
 	}
 
-	if !strings.HasPrefix(string(out), "Terraform v") {
+	// very basic sanity check
+	if !strings.Contains(string(out), "Terraform v") {
 		return fmt.Errorf("located executable at %s, but output of `terraform version` was:\n%s", execPath, out)
 	}
 


### PR DESCRIPTION
Releasing v0.5.0 failed because it's the first time the tests have been run since Core 0.13 GA, and they revealed a bug (fixed in https://github.com/hashicorp/terraform/pull/25811) in which the order of the "version" and "outdated" lines in the output of `terraform version` is reversed.

This applies to the following versions:
`0.13.0-beta2`
`0.13.0-beta3`
`0.13.0-rc1`
`0.13.0`

Given this bug in extant versions, I think we should just tolerate the different output order. It's a reasonable assumption that `terraform version` won't output anything else matching the version output regex.