### PR TITLE
Add better version matrix handling and additional version testing for all e2e tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,26 +30,27 @@ jobs:
       - win_install_go
       - go_test
 
-  "go112_build":
-    docker:
-      - image: circleci/golang:1.12
-    steps:
-      - checkout
-      - go_build
-  "go112_test":
+  go112_build:
     docker:
       - image: circleci/golang:1.12
     steps:
       - checkout
       - go_build
 
-  "go114_build":
+  go113_build:
+    docker:
+      - image: circleci/golang:1.13
+    steps:
+      - checkout
+      - go_build
+
+  go114_build:
     docker:
       - image: circleci/golang:1.14
     steps:
       - checkout
       - go_build
-  "go114_test":
+  go114_test:
     docker:
       - image: circleci/golang:1.14
     parameters:
@@ -59,25 +60,42 @@ jobs:
     steps:
       - checkout
       - go_test
-  "go114_vet":
+
+  go115_build:
     docker:
-      - image: circleci/golang:1.14
+      - image: circleci/golang:1.15
+    steps:
+      - checkout
+      - go_build
+  go115_test:
+    docker:
+      - image: circleci/golang:1.15
+    parameters:
+      test_results:
+        type: string
+        default: /tmp/test-results
+    steps:
+      - checkout
+      - go_test
+  go115_vet:
+    docker:
+      - image: circleci/golang:1.15
     steps:
       - checkout
       - run: go vet ./...
-  "go114_fmt":
+  go115_fmt:
     docker:
-      - image: circleci/golang:1.14
+      - image: circleci/golang:1.15
     steps:
       - checkout
       - run: gofmt -s -l .
-  "go114_release":
+  go115_release:
     docker:
-      - image: circleci/golang:1.14
+      - image: circleci/golang:1.15
     steps:
       - add_ssh_keys:
           fingerprints:
-            - "db:cf:97:b8:d6:ac:86:74:96:e1:54:e4:bc:27:2b:d0"
+            - db:cf:97:b8:d6:ac:86:74:96:e1:54:e4:bc:27:2b:d0
       - checkout
       - run: ./scripts/release/release.sh
 
@@ -86,50 +104,74 @@ workflows:
   pr:
     jobs:
       - winbuild
-      - wintest
-      - "go112_build"
-      - "go112_test"
-      - "go114_build"
-      - "go114_test":
+      - wintest:
           requires:
-            - "go114_build"
-      - "go114_vet":
+            - winbuild
+
+      # build only for these versions
+      - go112_build
+      - go113_build
+
+      - go114_build
+      - go114_test:
           requires:
-            - "go114_build"
-      - "go114_fmt":
+            - go114_build
+
+      - go115_build
+      - go115_test:
           requires:
-            - "go114_build"
+            - go115_build
+      - go115_vet:
+          requires:
+            - go115_build
+      - go115_fmt:
+          requires:
+            - go115_build
   release:
     jobs:
       - winbuild
-      - wintest
-      - "go112_build"
-      - "go112_test"
-      - "go114_build"
-      - "go114_test":
+      - wintest:
           requires:
-            - "go114_build"
-      - "go114_vet":
+            - winbuild
+
+      # build only for these versions
+      - go112_build
+      - go113_build
+
+      - go114_build
+      - go114_test:
           requires:
-            - "go114_build"
-      - "go114_fmt":
+            - go114_build
+
+      - go115_build
+      - go115_test:
           requires:
-            - "go114_build"
+            - go115_build
+      - go115_vet:
+          requires:
+            - go115_build
+      - go115_fmt:
+          requires:
+            - go115_build
+
       - trigger-release:
           filters:
             branches:
               only:
                 - master
           type: approval
-      - "go114_release":
+
+      - go115_release:
           filters:
             branches:
               only:
                 - master
           requires:
             - trigger-release
-            - "go114_test"
-            - "go114_vet"
-            - "go114_fmt"
-            - winbuild
+            - go112_build
+            - go113_build
+            - go114_test
+            - go115_test
+            - go115_vet
+            - go115_fmt
             - wintest

--- a/tfexec/errors.go
+++ b/tfexec/errors.go
@@ -19,6 +19,9 @@ func parseError(err error, stderr string) error {
 		return &ErrCLIUsage{stderr: stderr}
 	case regexp.MustCompile(`Error: Could not satisfy plugin requirements`).MatchString(stderr):
 		return &ErrNoInit{stderr: stderr}
+	case regexp.MustCompile(`Error: Could not load plugin`).MatchString(stderr):
+		// this string is present in 0.13
+		return &ErrNoInit{stderr: stderr}
 	case regexp.MustCompile(`Error: No configuration files`).MatchString(stderr):
 		return &ErrNoConfig{stderr: stderr}
 	default:

--- a/tfexec/internal/e2etest/apply_test.go
+++ b/tfexec/internal/e2etest/apply_test.go
@@ -4,14 +4,13 @@ import (
 	"context"
 	"testing"
 
+	"github.com/hashicorp/go-version"
+
 	"github.com/hashicorp/terraform-exec/tfexec"
-	"github.com/hashicorp/terraform-exec/tfexec/internal/testutil"
 )
 
 func TestApply(t *testing.T) {
-	runTest(t, []string{
-		testutil.Latest012,
-	}, "basic", func(t *testing.T, tfv string, tf *tfexec.Terraform) {
+	runTest(t, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
 		err := tf.Init(context.Background())
 		if err != nil {
 			t.Fatalf("error running Init in test directory: %s", err)

--- a/tfexec/internal/e2etest/apply_test.go
+++ b/tfexec/internal/e2etest/apply_test.go
@@ -4,20 +4,22 @@ import (
 	"context"
 	"testing"
 
+	"github.com/hashicorp/terraform-exec/tfexec"
 	"github.com/hashicorp/terraform-exec/tfexec/internal/testutil"
 )
 
 func TestApply(t *testing.T) {
-	tf, cleanup := setupFixture(t, testutil.Latest012, "basic")
-	defer cleanup()
+	runTest(t, []string{
+		testutil.Latest012,
+	}, "basic", func(t *testing.T, tfv string, tf *tfexec.Terraform) {
+		err := tf.Init(context.Background())
+		if err != nil {
+			t.Fatalf("error running Init in test directory: %s", err)
+		}
 
-	err := tf.Init(context.Background())
-	if err != nil {
-		t.Fatalf("error running Init in test directory: %s", err)
-	}
-
-	err = tf.Apply(context.Background())
-	if err != nil {
-		t.Fatalf("error running Apply: %s", err)
-	}
+		err = tf.Apply(context.Background())
+		if err != nil {
+			t.Fatalf("error running Apply: %s", err)
+		}
+	})
 }

--- a/tfexec/internal/e2etest/destroy_test.go
+++ b/tfexec/internal/e2etest/destroy_test.go
@@ -4,25 +4,27 @@ import (
 	"context"
 	"testing"
 
+	"github.com/hashicorp/terraform-exec/tfexec"
 	"github.com/hashicorp/terraform-exec/tfexec/internal/testutil"
 )
 
 func TestDestroy(t *testing.T) {
-	tf, cleanup := setupFixture(t, testutil.Latest012, "basic")
-	defer cleanup()
+	runTest(t, []string{
+		testutil.Latest012,
+	}, "basic", func(t *testing.T, tfv string, tf *tfexec.Terraform) {
+		err := tf.Init(context.Background())
+		if err != nil {
+			t.Fatalf("error running Init in test directory: %s", err)
+		}
 
-	err := tf.Init(context.Background())
-	if err != nil {
-		t.Fatalf("error running Init in test directory: %s", err)
-	}
+		err = tf.Apply(context.Background())
+		if err != nil {
+			t.Fatalf("error running Apply: %s", err)
+		}
 
-	err = tf.Apply(context.Background())
-	if err != nil {
-		t.Fatalf("error running Apply: %s", err)
-	}
-
-	err = tf.Destroy(context.Background())
-	if err != nil {
-		t.Fatalf("error running Destroy: %s", err)
-	}
+		err = tf.Destroy(context.Background())
+		if err != nil {
+			t.Fatalf("error running Destroy: %s", err)
+		}
+	})
 }

--- a/tfexec/internal/e2etest/destroy_test.go
+++ b/tfexec/internal/e2etest/destroy_test.go
@@ -4,14 +4,13 @@ import (
 	"context"
 	"testing"
 
+	"github.com/hashicorp/go-version"
+
 	"github.com/hashicorp/terraform-exec/tfexec"
-	"github.com/hashicorp/terraform-exec/tfexec/internal/testutil"
 )
 
 func TestDestroy(t *testing.T) {
-	runTest(t, []string{
-		testutil.Latest012,
-	}, "basic", func(t *testing.T, tfv string, tf *tfexec.Terraform) {
+	runTest(t, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
 		err := tf.Init(context.Background())
 		if err != nil {
 			t.Fatalf("error running Init in test directory: %s", err)

--- a/tfexec/internal/e2etest/errors_test.go
+++ b/tfexec/internal/e2etest/errors_test.go
@@ -9,35 +9,32 @@ import (
 	"os"
 	"testing"
 
+	"github.com/hashicorp/terraform-exec/tfexec"
 	"github.com/hashicorp/terraform-exec/tfexec/internal/testutil"
 )
 
 func TestUnparsedError(t *testing.T) {
 	// This simulates an unparsed error from the Cmd.Run method (in this case file not found). This
 	// is to ensure we don't miss raising unexpected errors in addition to parsed / well known ones.
-	for _, tfv := range []string{
+	runTest(t, []string{
 		testutil.Latest011,
 		testutil.Latest012,
 		testutil.Latest013,
-	} {
-		t.Run(tfv, func(t *testing.T) {
-			tf, cleanup := setupFixture(t, tfv, "")
-			defer cleanup()
+	}, "", func(t *testing.T, tfv string, tf *tfexec.Terraform) {
 
-			// force delete the working dir to cause an os.PathError
-			err := os.RemoveAll(tf.WorkingDir())
-			if err != nil {
-				t.Fatal(err)
-			}
+		// force delete the working dir to cause an os.PathError
+		err := os.RemoveAll(tf.WorkingDir())
+		if err != nil {
+			t.Fatal(err)
+		}
 
-			err = tf.Init(context.Background())
-			if err == nil {
-				t.Fatalf("expected error running Init, none returned")
-			}
-			var e *os.PathError
-			if !errors.As(err, &e) {
-				t.Fatalf("expected os.PathError, got %T, %s", err, err)
-			}
-		})
-	}
+		err = tf.Init(context.Background())
+		if err == nil {
+			t.Fatalf("expected error running Init, none returned")
+		}
+		var e *os.PathError
+		if !errors.As(err, &e) {
+			t.Fatalf("expected os.PathError, got %T, %s", err, err)
+		}
+	})
 }

--- a/tfexec/internal/e2etest/errors_test.go
+++ b/tfexec/internal/e2etest/errors_test.go
@@ -9,18 +9,15 @@ import (
 	"os"
 	"testing"
 
+	"github.com/hashicorp/go-version"
+
 	"github.com/hashicorp/terraform-exec/tfexec"
-	"github.com/hashicorp/terraform-exec/tfexec/internal/testutil"
 )
 
 func TestUnparsedError(t *testing.T) {
 	// This simulates an unparsed error from the Cmd.Run method (in this case file not found). This
 	// is to ensure we don't miss raising unexpected errors in addition to parsed / well known ones.
-	runTest(t, []string{
-		testutil.Latest011,
-		testutil.Latest012,
-		testutil.Latest013,
-	}, "", func(t *testing.T, tfv string, tf *tfexec.Terraform) {
+	runTest(t, "", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
 
 		// force delete the working dir to cause an os.PathError
 		err := os.RemoveAll(tf.WorkingDir())

--- a/tfexec/internal/e2etest/import_test.go
+++ b/tfexec/internal/e2etest/import_test.go
@@ -14,61 +14,57 @@ func TestImport(t *testing.T) {
 		expectedID      = "asdlfjksdlfkjsdlfk"
 		resourceAddress = "random_string.random_string"
 	)
-	ctx := context.Background()
 
-	for _, tfv := range []string{
+	runTest(t, []string{
 		testutil.Latest011, // doesn't support show JSON output, but does support import
 		testutil.Latest012,
 		testutil.Latest013,
-	} {
-		t.Run(tfv, func(t *testing.T) {
-			tf, cleanup := setupFixture(t, tfv, "import")
-			defer cleanup()
+	}, "import", func(t *testing.T, tfv string, tf *tfexec.Terraform) {
+		ctx := context.Background()
 
-			err := tf.Init(ctx, tfexec.Lock(false))
-			if err != nil {
-				t.Fatal(err)
+		err := tf.Init(ctx, tfexec.Lock(false))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Config is unnecessary here since its already the working dir, but just testing an additional flag
+		err = tf.Import(ctx, resourceAddress, expectedID, tfexec.DisableBackup(), tfexec.Lock(false), tfexec.Config(tf.WorkingDir()))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if strings.HasPrefix(tfv, "0.11.") {
+			t.Logf("skipping state assertion for 0.11")
+			return
+		}
+
+		state, err := tf.Show(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		for _, r := range state.Values.RootModule.Resources {
+			if r.Address != resourceAddress {
+				continue
 			}
 
-			// Config is unnecessary here since its already the working dir, but just testing an additional flag
-			err = tf.Import(ctx, resourceAddress, expectedID, tfexec.DisableBackup(), tfexec.Lock(false), tfexec.Config(tf.WorkingDir()))
-			if err != nil {
-				t.Fatal(err)
+			raw, ok := r.AttributeValues["id"]
+			if !ok {
+				t.Fatal("value not found for \"id\" attribute")
+			}
+			actual, ok := raw.(string)
+			if !ok {
+				t.Fatalf("unable to cast %T to string: %#v", raw, raw)
 			}
 
-			if strings.HasPrefix(tfv, "0.11.") {
-				t.Logf("skipping state assertion for 0.11")
-				return
+			if actual != expectedID {
+				t.Fatalf("expected %q, got %q", expectedID, actual)
 			}
 
-			state, err := tf.Show(ctx)
-			if err != nil {
-				t.Fatal(err)
-			}
+			// success
+			return
+		}
 
-			for _, r := range state.Values.RootModule.Resources {
-				if r.Address != resourceAddress {
-					continue
-				}
-
-				raw, ok := r.AttributeValues["id"]
-				if !ok {
-					t.Fatal("value not found for \"id\" attribute")
-				}
-				actual, ok := raw.(string)
-				if !ok {
-					t.Fatalf("unable to cast %T to string: %#v", raw, raw)
-				}
-
-				if actual != expectedID {
-					t.Fatalf("expected %q, got %q", expectedID, actual)
-				}
-
-				// success
-				return
-			}
-
-			t.Fatalf("imported resource %q not found", resourceAddress)
-		})
-	}
+		t.Fatalf("imported resource %q not found", resourceAddress)
+	})
 }

--- a/tfexec/internal/e2etest/import_test.go
+++ b/tfexec/internal/e2etest/import_test.go
@@ -2,11 +2,11 @@ package e2etest
 
 import (
 	"context"
-	"strings"
 	"testing"
 
+	"github.com/hashicorp/go-version"
+
 	"github.com/hashicorp/terraform-exec/tfexec"
-	"github.com/hashicorp/terraform-exec/tfexec/internal/testutil"
 )
 
 func TestImport(t *testing.T) {
@@ -15,11 +15,7 @@ func TestImport(t *testing.T) {
 		resourceAddress = "random_string.random_string"
 	)
 
-	runTest(t, []string{
-		testutil.Latest011, // doesn't support show JSON output, but does support import
-		testutil.Latest012,
-		testutil.Latest013,
-	}, "import", func(t *testing.T, tfv string, tf *tfexec.Terraform) {
+	runTest(t, "import", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
 		ctx := context.Background()
 
 		err := tf.Init(ctx, tfexec.Lock(false))
@@ -33,7 +29,7 @@ func TestImport(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if strings.HasPrefix(tfv, "0.11.") {
+		if tfv.LessThan(version.Must(version.NewVersion("0.12.0"))) {
 			t.Logf("skipping state assertion for 0.11")
 			return
 		}

--- a/tfexec/internal/e2etest/init_test.go
+++ b/tfexec/internal/e2etest/init_test.go
@@ -4,14 +4,13 @@ import (
 	"context"
 	"testing"
 
+	"github.com/hashicorp/go-version"
+
 	"github.com/hashicorp/terraform-exec/tfexec"
-	"github.com/hashicorp/terraform-exec/tfexec/internal/testutil"
 )
 
 func TestInit(t *testing.T) {
-	runTest(t, []string{
-		testutil.Latest012,
-	}, "basic", func(t *testing.T, tfv string, tf *tfexec.Terraform) {
+	runTest(t, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
 		err := tf.Init(context.Background())
 		if err != nil {
 			t.Fatalf("error running Init in test directory: %s", err)

--- a/tfexec/internal/e2etest/init_test.go
+++ b/tfexec/internal/e2etest/init_test.go
@@ -4,15 +4,17 @@ import (
 	"context"
 	"testing"
 
+	"github.com/hashicorp/terraform-exec/tfexec"
 	"github.com/hashicorp/terraform-exec/tfexec/internal/testutil"
 )
 
 func TestInit(t *testing.T) {
-	tf, cleanup := setupFixture(t, testutil.Latest012, "basic")
-	defer cleanup()
-
-	err := tf.Init(context.Background())
-	if err != nil {
-		t.Fatalf("error running Init in test directory: %s", err)
-	}
+	runTest(t, []string{
+		testutil.Latest012,
+	}, "basic", func(t *testing.T, tfv string, tf *tfexec.Terraform) {
+		err := tf.Init(context.Background())
+		if err != nil {
+			t.Fatalf("error running Init in test directory: %s", err)
+		}
+	})
 }

--- a/tfexec/internal/e2etest/output_test.go
+++ b/tfexec/internal/e2etest/output_test.go
@@ -4,20 +4,22 @@ import (
 	"context"
 	"testing"
 
+	"github.com/hashicorp/terraform-exec/tfexec"
 	"github.com/hashicorp/terraform-exec/tfexec/internal/testutil"
 )
 
 func TestOutput(t *testing.T) {
-	tf, cleanup := setupFixture(t, testutil.Latest012, "basic")
-	defer cleanup()
+	runTest(t, []string{
+		testutil.Latest012,
+	}, "basic", func(t *testing.T, tfv string, tf *tfexec.Terraform) {
+		err := tf.Init(context.Background())
+		if err != nil {
+			t.Fatalf("error running Init in test directory: %s", err)
+		}
 
-	err := tf.Init(context.Background())
-	if err != nil {
-		t.Fatalf("error running Init in test directory: %s", err)
-	}
-
-	_, err = tf.Output(context.Background())
-	if err != nil {
-		t.Fatalf("error running Output: %s", err)
-	}
+		_, err = tf.Output(context.Background())
+		if err != nil {
+			t.Fatalf("error running Output: %s", err)
+		}
+	})
 }

--- a/tfexec/internal/e2etest/output_test.go
+++ b/tfexec/internal/e2etest/output_test.go
@@ -4,14 +4,18 @@ import (
 	"context"
 	"testing"
 
+	"github.com/hashicorp/go-version"
+
 	"github.com/hashicorp/terraform-exec/tfexec"
-	"github.com/hashicorp/terraform-exec/tfexec/internal/testutil"
 )
 
-func TestOutput(t *testing.T) {
-	runTest(t, []string{
-		testutil.Latest012,
-	}, "basic", func(t *testing.T, tfv string, tf *tfexec.Terraform) {
+func TestOutput_noOutputs(t *testing.T) {
+	runTest(t, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+		if tfv.LessThan(version.Must(version.NewVersion("0.12.14"))) {
+			// https://github.com/hashicorp/terraform/blob/v0.12/CHANGELOG.md#01214-november-13-2019
+			t.Skip("no outputs being success (instead of error) was changed in 0.12.14")
+		}
+
 		err := tf.Init(context.Background())
 		if err != nil {
 			t.Fatalf("error running Init in test directory: %s", err)

--- a/tfexec/internal/e2etest/plan_test.go
+++ b/tfexec/internal/e2etest/plan_test.go
@@ -4,14 +4,13 @@ import (
 	"context"
 	"testing"
 
+	"github.com/hashicorp/go-version"
+
 	"github.com/hashicorp/terraform-exec/tfexec"
-	"github.com/hashicorp/terraform-exec/tfexec/internal/testutil"
 )
 
 func TestPlan(t *testing.T) {
-	runTest(t, []string{
-		testutil.Latest012,
-	}, "basic", func(t *testing.T, tfv string, tf *tfexec.Terraform) {
+	runTest(t, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
 		err := tf.Init(context.Background())
 		if err != nil {
 			t.Fatalf("error running Init in test directory: %s", err)

--- a/tfexec/internal/e2etest/plan_test.go
+++ b/tfexec/internal/e2etest/plan_test.go
@@ -4,20 +4,23 @@ import (
 	"context"
 	"testing"
 
+	"github.com/hashicorp/terraform-exec/tfexec"
 	"github.com/hashicorp/terraform-exec/tfexec/internal/testutil"
 )
 
 func TestPlan(t *testing.T) {
-	tf, cleanup := setupFixture(t, testutil.Latest012, "basic")
-	defer cleanup()
+	runTest(t, []string{
+		testutil.Latest012,
+	}, "basic", func(t *testing.T, tfv string, tf *tfexec.Terraform) {
+		err := tf.Init(context.Background())
+		if err != nil {
+			t.Fatalf("error running Init in test directory: %s", err)
+		}
 
-	err := tf.Init(context.Background())
-	if err != nil {
-		t.Fatalf("error running Init in test directory: %s", err)
-	}
+		err = tf.Plan(context.Background())
+		if err != nil {
+			t.Fatalf("error running Plan: %s", err)
+		}
+	})
 
-	err = tf.Plan(context.Background())
-	if err != nil {
-		t.Fatalf("error running Plan: %s", err)
-	}
 }

--- a/tfexec/internal/e2etest/providers_schema_test.go
+++ b/tfexec/internal/e2etest/providers_schema_test.go
@@ -7,89 +7,124 @@ import (
 	"testing"
 
 	"github.com/davecgh/go-spew/spew"
-	"github.com/hashicorp/terraform-exec/tfexec"
-	"github.com/hashicorp/terraform-exec/tfexec/internal/testutil"
+	"github.com/hashicorp/go-version"
 	tfjson "github.com/hashicorp/terraform-json"
 	"github.com/zclconf/go-cty/cty"
+
+	"github.com/hashicorp/terraform-exec/tfexec"
+)
+
+var (
+	providersSchemaJSONMinVersion = version.Must(version.NewVersion("0.12.0"))
 )
 
 func TestProvidersSchema(t *testing.T) {
 	for i, c := range []struct {
 		fixtureDir string
-		expected   *tfjson.ProviderSchemas
+		expected   func(*version.Version) *tfjson.ProviderSchemas
 	}{
 		{
-			"basic", &tfjson.ProviderSchemas{
-				FormatVersion: "0.1",
-				Schemas: map[string]*tfjson.ProviderSchema{
-					"null": {
-						ConfigSchema: &tfjson.Schema{
-							Version: 0,
-							Block:   &tfjson.SchemaBlock{},
-						},
-						ResourceSchemas: map[string]*tfjson.Schema{
-							"null_resource": {
+			"basic", func(tfv *version.Version) *tfjson.ProviderSchemas {
+				dk := tfjson.SchemaDescriptionKindPlain
+				// HACK: this is a bug? the contstant value is "plaintext" but "plain" is output,
+				// not sure if its in tfjson or what
+				dk = "plain"
+
+				providerName := "registry.terraform.io/hashicorp/null"
+
+				if tfv.LessThan(version.Must(version.NewVersion("0.13.0"))) {
+					providerName = "null"
+					dk = ""
+				}
+
+				return &tfjson.ProviderSchemas{
+					FormatVersion: "0.1",
+					Schemas: map[string]*tfjson.ProviderSchema{
+						providerName: {
+							ConfigSchema: &tfjson.Schema{
 								Version: 0,
 								Block: &tfjson.SchemaBlock{
-									Attributes: map[string]*tfjson.SchemaAttribute{
-										"id": {
-											AttributeType: cty.String,
-											Optional:      true,
-											Computed:      true,
-										},
-										"triggers": {
-											AttributeType: cty.Map(cty.String),
-											Optional:      true,
+									DescriptionKind: dk,
+								},
+							},
+							ResourceSchemas: map[string]*tfjson.Schema{
+								"null_resource": {
+									Version: 0,
+									Block: &tfjson.SchemaBlock{
+										DescriptionKind: dk,
+										Attributes: map[string]*tfjson.SchemaAttribute{
+											"id": {
+												AttributeType:   cty.String,
+												Optional:        true,
+												Computed:        true,
+												DescriptionKind: dk,
+											},
+											"triggers": {
+												AttributeType:   cty.Map(cty.String),
+												Optional:        true,
+												DescriptionKind: dk,
+											},
 										},
 									},
 								},
 							},
-						},
-						DataSourceSchemas: map[string]*tfjson.Schema{
-							"null_data_source": {
-								Version: 0,
-								Block: &tfjson.SchemaBlock{
-									Attributes: map[string]*tfjson.SchemaAttribute{
-										"has_computed_default": {
-											AttributeType: cty.String,
-											Optional:      true,
-											Computed:      true,
-										},
-										"id": {
-											AttributeType: cty.String,
-											Optional:      true,
-											Computed:      true,
-										},
-										"inputs": {
-											AttributeType: cty.Map(cty.String),
-											Optional:      true,
-										},
-										"outputs": {
-											AttributeType: cty.Map(cty.String),
-											Computed:      true,
-										},
-										"random": {
-											AttributeType: cty.String,
-											Computed:      true,
+							DataSourceSchemas: map[string]*tfjson.Schema{
+								"null_data_source": {
+									Version: 0,
+									Block: &tfjson.SchemaBlock{
+										DescriptionKind: dk,
+										Attributes: map[string]*tfjson.SchemaAttribute{
+											"has_computed_default": {
+												AttributeType:   cty.String,
+												Optional:        true,
+												Computed:        true,
+												DescriptionKind: dk,
+											},
+											"id": {
+												AttributeType:   cty.String,
+												Optional:        true,
+												Computed:        true,
+												DescriptionKind: dk,
+											},
+											"inputs": {
+												AttributeType:   cty.Map(cty.String),
+												Optional:        true,
+												DescriptionKind: dk,
+											},
+											"outputs": {
+												AttributeType:   cty.Map(cty.String),
+												Computed:        true,
+												DescriptionKind: dk,
+											},
+											"random": {
+												AttributeType:   cty.String,
+												Computed:        true,
+												DescriptionKind: dk,
+											},
 										},
 									},
 								},
 							},
-						},
-					}},
+						}},
+				}
 			},
 		},
 		{
-			"empty_with_tf_file", &tfjson.ProviderSchemas{
-				FormatVersion: "0.1",
-				Schemas:       nil,
+			"empty_with_tf_file", func(*version.Version) *tfjson.ProviderSchemas {
+				return &tfjson.ProviderSchemas{
+					FormatVersion: "0.1",
+					Schemas:       nil,
+				}
 			},
 		},
 	} {
+		c := c
 		t.Run(fmt.Sprintf("%d %s", i, c.fixtureDir), func(t *testing.T) {
-			runTest(t, []string{
-				testutil.Latest012,
-			}, c.fixtureDir, func(t *testing.T, tfv string, tf *tfexec.Terraform) {
+			runTest(t, c.fixtureDir, func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+				if tfv.LessThan(providersSchemaJSONMinVersion) {
+					t.Skip("providers schema -json was added in 0.12")
+				}
+
 				err := tf.Init(context.Background())
 				if err != nil {
 					t.Fatalf("error running Init in test directory: %s", err)
@@ -100,11 +135,16 @@ func TestProvidersSchema(t *testing.T) {
 					t.Fatalf("error running ProvidersSchema in test directory: %s", err)
 				}
 
-				if !reflect.DeepEqual(schemas, c.expected) {
-					t.Fatalf("expected %+v, but got %+v", spew.Sdump(c.expected), spew.Sdump(schemas))
+				expected := c.expected(tfv)
+				if !reflect.DeepEqual(schemas, expected) {
+					t.Fatalf("expected %+v, but got %+v", spew.Sdump(expected), spew.Sdump(schemas))
 				}
 			})
 		})
 	}
 
+}
+
+func TestProvidersSchema_versionMismatch(t *testing.T) {
+	t.Skip("TODO! add version mismatch test for 0.11 as -json was added in 0.12 (I think)")
 }

--- a/tfexec/internal/e2etest/show_test.go
+++ b/tfexec/internal/e2etest/show_test.go
@@ -73,12 +73,10 @@ func TestShow_errInitRequired(t *testing.T) {
 			t.Skip("terraform show was added in Terraform 0.12, so test is not valid")
 		}
 
+		var noInit *tfexec.ErrNoInit
 		_, err := tf.Show(context.Background())
-		if err == nil {
-			t.Fatal("expected Show to error, but it did not")
-		}
-		if _, ok := err.(*tfexec.ErrNoInit); !ok {
-			t.Fatalf("expected error %s to be ErrNoInit", err)
+		if !errors.As(err, &noInit) {
+			t.Fatalf("expected error ErrNoInit, got %T: %s", err, err)
 		}
 	})
 }
@@ -93,7 +91,7 @@ func TestShow_versionMismatch(t *testing.T) {
 		var mismatch *tfexec.ErrVersionMismatch
 		_, err := tf.Show(context.Background())
 		if !errors.As(err, &mismatch) {
-			t.Fatal("expected version mismatch error")
+			t.Fatalf("expected version mismatch error, got %T %s", err, err)
 		}
 		if mismatch.Actual != "0.11.14" {
 			t.Fatalf("expected version 0.11.14, got %q", mismatch.Actual)

--- a/tfexec/internal/e2etest/show_test.go
+++ b/tfexec/internal/e2etest/show_test.go
@@ -13,74 +13,78 @@ import (
 )
 
 func TestShow(t *testing.T) {
-	tf, cleanup := setupFixture(t, testutil.Latest012, "basic_with_state")
-	defer cleanup()
-
-	expected := tfjson.State{
-		FormatVersion: "0.1",
-		// this is the version that wrote state, not the version that is running
-		TerraformVersion: "0.12.24",
-		Values: &tfjson.StateValues{
-			RootModule: &tfjson.StateModule{
-				Resources: []*tfjson.StateResource{{
-					Address: "null_resource.foo",
-					AttributeValues: map[string]interface{}{
-						"id":       "5510719323588825107",
-						"triggers": nil,
-					},
-					Mode:         tfjson.ManagedResourceMode,
-					Type:         "null_resource",
-					Name:         "foo",
-					ProviderName: "null",
-				}},
+	runTest(t, []string{
+		testutil.Latest012,
+	}, "basic_with_state", func(t *testing.T, tfv string, tf *tfexec.Terraform) {
+		expected := tfjson.State{
+			FormatVersion: "0.1",
+			// this is the version that wrote state, not the version that is running
+			TerraformVersion: "0.12.24",
+			Values: &tfjson.StateValues{
+				RootModule: &tfjson.StateModule{
+					Resources: []*tfjson.StateResource{{
+						Address: "null_resource.foo",
+						AttributeValues: map[string]interface{}{
+							"id":       "5510719323588825107",
+							"triggers": nil,
+						},
+						Mode:         tfjson.ManagedResourceMode,
+						Type:         "null_resource",
+						Name:         "foo",
+						ProviderName: "null",
+					}},
+				},
 			},
-		},
-	}
+		}
 
-	err := tf.Init(context.Background())
-	if err != nil {
-		t.Fatalf("error running Init in test directory: %s", err)
-	}
+		err := tf.Init(context.Background())
+		if err != nil {
+			t.Fatalf("error running Init in test directory: %s", err)
+		}
 
-	actual, err := tf.Show(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
+		actual, err := tf.Show(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	if !reflect.DeepEqual(actual, &expected) {
-		t.Fatalf("actual: %s\nexpected: %s", spew.Sdump(actual), spew.Sdump(expected))
-	}
+		if !reflect.DeepEqual(actual, &expected) {
+			t.Fatalf("actual: %s\nexpected: %s", spew.Sdump(actual), spew.Sdump(expected))
+		}
+	})
 }
 
 func TestShow_errInitRequired(t *testing.T) {
-	tf, cleanup := setupFixture(t, testutil.Latest012, "basic")
-	defer cleanup()
-
-	_, err := tf.Show(context.Background())
-	if err == nil {
-		t.Fatal("expected Show to error, but it did not")
-	}
-	if _, ok := err.(*tfexec.ErrNoInit); !ok {
-		t.Fatalf("expected error %s to be ErrNoInit", err)
-	}
+	runTest(t, []string{
+		testutil.Latest012,
+	}, "basic", func(t *testing.T, tfv string, tf *tfexec.Terraform) {
+		_, err := tf.Show(context.Background())
+		if err == nil {
+			t.Fatal("expected Show to error, but it did not")
+		}
+		if _, ok := err.(*tfexec.ErrNoInit); !ok {
+			t.Fatalf("expected error %s to be ErrNoInit", err)
+		}
+	})
 }
 
 func TestShow_compatible(t *testing.T) {
-	tf, cleanup := setupFixture(t, testutil.Latest011, "basic")
-	defer cleanup()
-
-	var mismatch *tfexec.ErrVersionMismatch
-	_, err := tf.Show(context.Background())
-	if !errors.As(err, &mismatch) {
-		t.Fatal("expected version mismatch error")
-	}
-	if mismatch.Actual != "0.11.14" {
-		t.Fatalf("expected version 0.11.14, got %q", mismatch.Actual)
-	}
-	if mismatch.MinInclusive != "0.12.0" {
-		t.Fatalf("expected min 0.12.0, got %q", mismatch.MinInclusive)
-	}
-	if mismatch.MaxExclusive != "-" {
-		t.Fatalf("expected max -, got %q", mismatch.MaxExclusive)
-	}
+	runTest(t, []string{
+		// terraform show was added in Terraform 0.12
+		testutil.Latest011,
+	}, "basic", func(t *testing.T, tfv string, tf *tfexec.Terraform) {
+		var mismatch *tfexec.ErrVersionMismatch
+		_, err := tf.Show(context.Background())
+		if !errors.As(err, &mismatch) {
+			t.Fatal("expected version mismatch error")
+		}
+		if mismatch.Actual != "0.11.14" {
+			t.Fatalf("expected version 0.11.14, got %q", mismatch.Actual)
+		}
+		if mismatch.MinInclusive != "0.12.0" {
+			t.Fatalf("expected min 0.12.0, got %q", mismatch.MinInclusive)
+		}
+		if mismatch.MaxExclusive != "-" {
+			t.Fatalf("expected max -, got %q", mismatch.MaxExclusive)
+		}
+	})
 }

--- a/tfexec/internal/e2etest/util_test.go
+++ b/tfexec/internal/e2etest/util_test.go
@@ -10,12 +10,26 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/hashicorp/go-version"
+
 	"github.com/hashicorp/terraform-exec/tfexec"
+	"github.com/hashicorp/terraform-exec/tfexec/internal/testutil"
 )
 
 const testFixtureDir = "testdata"
 
-func runTest(t *testing.T, versions []string, fixtureName string, cb func(t *testing.T, tfVersion string, tf *tfexec.Terraform)) {
+func runTest(t *testing.T, fixtureName string, cb func(t *testing.T, tfVersion *version.Version, tf *tfexec.Terraform)) {
+	t.Helper()
+	runTestVersions(t, []string{
+		testutil.Latest011,
+		testutil.Latest012,
+		testutil.Latest013,
+	}, fixtureName, cb)
+}
+
+// runTestVersions should probably not be used directly, better to use
+// t.Skip in your test with a comment as to why you shouldn't test on a version
+func runTestVersions(t *testing.T, versions []string, fixtureName string, cb func(t *testing.T, tfVersion *version.Version, tf *tfexec.Terraform)) {
 	t.Helper()
 
 	// TODO: if overriding latest for master code, skip all other tests
@@ -49,7 +63,7 @@ func runTest(t *testing.T, versions []string, fixtureName string, cb func(t *tes
 			}
 
 			// TODO: capture panics here?
-			cb(t, tfv, tf)
+			cb(t, version.Must(version.NewVersion(tfv)), tf)
 		})
 	}
 }

--- a/tfexec/internal/e2etest/version_test.go
+++ b/tfexec/internal/e2etest/version_test.go
@@ -8,41 +8,39 @@ import (
 	"github.com/hashicorp/terraform-exec/tfexec/internal/testutil"
 )
 
-func TestVersion(t *testing.T) {
-	ctx := context.Background()
+// // adding 0.13.0 here due to the regression fixed in https://github.com/hashicorp/terraform/pull/25811
+// "0.13.0",
 
-	for _, tfv := range []string{
+func TestVersion(t *testing.T) {
+	runTest(t, []string{
 		testutil.Latest011,
 		testutil.Latest012,
 		testutil.Latest013,
-	} {
-		t.Run(tfv, func(t *testing.T) {
-			tf, cleanup := setupFixture(t, tfv, "basic")
-			defer cleanup()
+	}, "basic", func(t *testing.T, tfv string, tf *tfexec.Terraform) {
+		ctx := context.Background()
 
-			err := tf.Init(ctx, tfexec.Lock(false))
-			if err != nil {
-				t.Fatal(err)
-			}
+		err := tf.Init(ctx, tfexec.Lock(false))
+		if err != nil {
+			t.Fatal(err)
+		}
 
-			v, _, err := tf.Version(ctx, false)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if v.String() != tfv {
-				t.Fatalf("expected version %q, got %q", tfv, v)
-			}
+		v, _, err := tf.Version(ctx, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if v.String() != tfv {
+			t.Fatalf("expected version %q, got %q", tfv, v)
+		}
 
-			// TODO: test/assert provider info
+		// TODO: test/assert provider info
 
-			// force execution / skip cache as well
-			v, _, err = tf.Version(ctx, true)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if v.String() != tfv {
-				t.Fatalf("expected version %q, got %q", tfv, v)
-			}
-		})
-	}
+		// force execution / skip cache as well
+		v, _, err = tf.Version(ctx, true)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if v.String() != tfv {
+			t.Fatalf("expected version %q, got %q", tfv, v)
+		}
+	})
 }

--- a/tfexec/internal/e2etest/version_test.go
+++ b/tfexec/internal/e2etest/version_test.go
@@ -4,19 +4,13 @@ import (
 	"context"
 	"testing"
 
+	"github.com/hashicorp/go-version"
+
 	"github.com/hashicorp/terraform-exec/tfexec"
-	"github.com/hashicorp/terraform-exec/tfexec/internal/testutil"
 )
 
-// // adding 0.13.0 here due to the regression fixed in https://github.com/hashicorp/terraform/pull/25811
-// "0.13.0",
-
 func TestVersion(t *testing.T) {
-	runTest(t, []string{
-		testutil.Latest011,
-		testutil.Latest012,
-		testutil.Latest013,
-	}, "basic", func(t *testing.T, tfv string, tf *tfexec.Terraform) {
+	runTest(t, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
 		ctx := context.Background()
 
 		err := tf.Init(ctx, tfexec.Lock(false))
@@ -28,7 +22,7 @@ func TestVersion(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if v.String() != tfv {
+		if !v.Equal(tfv) {
 			t.Fatalf("expected version %q, got %q", tfv, v)
 		}
 
@@ -39,7 +33,7 @@ func TestVersion(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if v.String() != tfv {
+		if !v.Equal(tfv) {
 			t.Fatalf("expected version %q, got %q", tfv, v)
 		}
 	})

--- a/tfexec/internal/testutil/tfcache.go
+++ b/tfexec/internal/testutil/tfcache.go
@@ -12,7 +12,7 @@ import (
 const (
 	Latest011 = "0.11.14"
 	Latest012 = "0.12.29"
-	Latest013 = "0.13.0-rc1"
+	Latest013 = "0.13.0"
 )
 
 type TFCache struct {
@@ -48,6 +48,7 @@ func (tf *TFCache) Version(t *testing.T, v string) string {
 		if err != nil {
 			t.Fatal(err)
 		}
+
 		path, err = tfinstall.Find(tfinstall.ExactVersion(v, dir))
 		if err != nil {
 			t.Fatalf("error installing terraform version %q: %s", v, err)


### PR DESCRIPTION
In addition to TF version matrix updates, added go 1.15, changed 1.12 and 1.13 to building only (not testing). Testing only in 1.14 and 1.15 as they are the support Go versions currently.