### PR TITLE
Relax logger interface, log testing CLI command

### DIFF
--- a/tfexec/internal/e2etest/util_test.go
+++ b/tfexec/internal/e2etest/util_test.go
@@ -66,12 +66,22 @@ func runTestVersions(t *testing.T, versions []string, fixtureName string, cb fun
 			tf.SetStdout(&stdouterr)
 			tf.SetStderr(&stdouterr)
 
+			tf.SetLogger(&testingPrintfer{t})
+
 			// TODO: capture panics here?
 			cb(t, version.Must(version.NewVersion(tfv)), tf)
 
 			t.Logf("CLI Output:\n%s", stdouterr.String())
 		})
 	}
+}
+
+type testingPrintfer struct {
+	t *testing.T
+}
+
+func (t *testingPrintfer) Printf(format string, v ...interface{}) {
+	t.t.Logf(format, v...)
 }
 
 func copyFiles(path string, dstPath string) error {

--- a/tfexec/terraform.go
+++ b/tfexec/terraform.go
@@ -12,6 +12,10 @@ import (
 	"github.com/hashicorp/go-version"
 )
 
+type printfer interface {
+	Printf(format string, v ...interface{})
+}
+
 type Terraform struct {
 	execPath   string
 	workingDir string
@@ -19,7 +23,7 @@ type Terraform struct {
 
 	stdout  io.Writer
 	stderr  io.Writer
-	logger  *log.Logger
+	logger  printfer
 	logPath string
 
 	versionLock  sync.Mutex
@@ -77,7 +81,7 @@ func (tf *Terraform) SetEnv(env map[string]string) error {
 }
 
 // SetLogger specifies a logger for tfexec to use.
-func (tf *Terraform) SetLogger(logger *log.Logger) {
+func (tf *Terraform) SetLogger(logger printfer) {
 	tf.logger = logger
 }
 


### PR DESCRIPTION
This sets the logger to e2etests (and relaxes the logger requirements to not be a struct, but an interface).