### PR TITLE
implement [DIR] positional arg

### DIFF
--- a/tfexec/destroy.go
+++ b/tfexec/destroy.go
@@ -9,6 +9,7 @@ import (
 
 type destroyConfig struct {
 	backup string
+	dir    string
 	lock   bool
 
 	// LockTimeout must be a string with time unit, e.g. '10s'
@@ -33,6 +34,10 @@ var defaultDestroyOptions = destroyConfig{
 
 type DestroyOption interface {
 	configureDestroy(*destroyConfig)
+}
+
+func (opt *DirOption) configureDestroy(conf *destroyConfig) {
+	conf.dir = opt.path
 }
 
 func (opt *ParallelismOption) configureDestroy(conf *destroyConfig) {
@@ -120,6 +125,11 @@ func (tf *Terraform) destroyCmd(ctx context.Context, opts ...DestroyOption) *exe
 		for _, v := range c.vars {
 			args = append(args, "-var", v)
 		}
+	}
+
+	// optional positional argument
+	if c.dir != "" {
+		args = append(args, c.dir)
 	}
 
 	return tf.buildTerraformCmd(ctx, args...)

--- a/tfexec/destroy_test.go
+++ b/tfexec/destroy_test.go
@@ -36,7 +36,7 @@ func TestDestroyCmd(t *testing.T) {
 	})
 
 	t.Run("override all defaults", func(t *testing.T) {
-		destroyCmd := tf.destroyCmd(context.Background(), Backup("testbackup"), LockTimeout("200s"), State("teststate"), StateOut("teststateout"), VarFile("testvarfile"), Lock(false), Parallelism(99), Refresh(false), Target("target1"), Target("target2"), Var("var1=foo"), Var("var2=bar"))
+		destroyCmd := tf.destroyCmd(context.Background(), Backup("testbackup"), LockTimeout("200s"), State("teststate"), StateOut("teststateout"), VarFile("testvarfile"), Lock(false), Parallelism(99), Refresh(false), Target("target1"), Target("target2"), Var("var1=foo"), Var("var2=bar"), Dir("destroydir"))
 
 		assertCmd(t, []string{
 			"destroy",
@@ -55,6 +55,7 @@ func TestDestroyCmd(t *testing.T) {
 			"-target=target2",
 			"-var", "var1=foo",
 			"-var", "var2=bar",
+			"destroydir",
 		}, nil, destroyCmd)
 	})
 }

--- a/tfexec/init.go
+++ b/tfexec/init.go
@@ -9,6 +9,7 @@ import (
 type initConfig struct {
 	backend       bool
 	backendConfig []string
+	dir           string
 	forceCopy     bool
 	fromModule    string
 	get           bool
@@ -43,6 +44,10 @@ func (opt *BackendOption) configureInit(conf *initConfig) {
 
 func (opt *BackendConfigOption) configureInit(conf *initConfig) {
 	conf.backendConfig = append(conf.backendConfig, opt.path)
+}
+
+func (opt *DirOption) configureInit(conf *initConfig) {
+	conf.dir = opt.path
 }
 
 func (opt *FromModuleOption) configureInit(conf *initConfig) {
@@ -125,6 +130,11 @@ func (tf *Terraform) initCmd(ctx context.Context, opts ...InitOption) *exec.Cmd 
 		for _, pd := range c.pluginDir {
 			args = append(args, "-plugin-dir="+pd)
 		}
+	}
+
+	// optional positional argument
+	if c.dir != "" {
+		args = append(args, c.dir)
 	}
 
 	return tf.buildTerraformCmd(ctx, args...)

--- a/tfexec/init_test.go
+++ b/tfexec/init_test.go
@@ -43,7 +43,7 @@ func TestInitCmd(t *testing.T) {
 	})
 
 	t.Run("override all defaults", func(t *testing.T) {
-		initCmd := tf.initCmd(context.Background(), Backend(false), BackendConfig("confpath1"), BackendConfig("confpath2"), FromModule("testsource"), Get(false), GetPlugins(false), Lock(false), LockTimeout("999s"), PluginDir("testdir1"), PluginDir("testdir2"), Reconfigure(true), Upgrade(true), VerifyPlugins(false))
+		initCmd := tf.initCmd(context.Background(), Backend(false), BackendConfig("confpath1"), BackendConfig("confpath2"), FromModule("testsource"), Get(false), GetPlugins(false), Lock(false), LockTimeout("999s"), PluginDir("testdir1"), PluginDir("testdir2"), Reconfigure(true), Upgrade(true), VerifyPlugins(false), Dir("initdir"))
 
 		assertCmd(t, []string{
 			"init",
@@ -63,6 +63,7 @@ func TestInitCmd(t *testing.T) {
 			"-backend-config=confpath2",
 			"-plugin-dir=testdir1",
 			"-plugin-dir=testdir2",
+			"initdir",
 		}, nil, initCmd)
 	})
 }

--- a/tfexec/options.go
+++ b/tfexec/options.go
@@ -45,6 +45,14 @@ func Config(path string) *ConfigOption {
 	return &ConfigOption{path}
 }
 
+type DirOption struct {
+	path string
+}
+
+func Dir(path string) *DirOption {
+	return &DirOption{path}
+}
+
 type DirOrPlanOption struct {
 	path string
 }

--- a/tfexec/plan.go
+++ b/tfexec/plan.go
@@ -9,6 +9,7 @@ import (
 
 type planConfig struct {
 	destroy     bool
+	dir         string
 	lock        bool
 	lockTimeout string
 	out         string
@@ -30,6 +31,10 @@ var defaultPlanOptions = planConfig{
 
 type PlanOption interface {
 	configurePlan(*planConfig)
+}
+
+func (opt *DirOption) configurePlan(conf *planConfig) {
+	conf.dir = opt.path
 }
 
 func (opt *VarFileOption) configurePlan(conf *planConfig) {
@@ -119,6 +124,11 @@ func (tf *Terraform) planCmd(ctx context.Context, opts ...PlanOption) *exec.Cmd 
 		for _, v := range c.vars {
 			args = append(args, "-var", v)
 		}
+	}
+
+	// optional positional argument
+	if c.dir != "" {
+		args = append(args, c.dir)
 	}
 
 	return tf.buildTerraformCmd(ctx, args...)

--- a/tfexec/plan_test.go
+++ b/tfexec/plan_test.go
@@ -35,7 +35,7 @@ func TestPlanCmd(t *testing.T) {
 	})
 
 	t.Run("override all defaults", func(t *testing.T) {
-		planCmd := tf.planCmd(context.Background(), Destroy(true), Lock(false), LockTimeout("22s"), Out("whale"), Parallelism(42), Refresh(false), State("marvin"), Target("zaphod"), Target("beeblebrox"), Var("android=paranoid"), Var("brain_size=planet"), VarFile("trillian"))
+		planCmd := tf.planCmd(context.Background(), Destroy(true), Lock(false), LockTimeout("22s"), Out("whale"), Parallelism(42), Refresh(false), State("marvin"), Target("zaphod"), Target("beeblebrox"), Var("android=paranoid"), Var("brain_size=planet"), VarFile("trillian"), Dir("earth"))
 
 		assertCmd(t, []string{
 			"plan",
@@ -53,6 +53,7 @@ func TestPlanCmd(t *testing.T) {
 			"-target=beeblebrox",
 			"-var", "android=paranoid",
 			"-var", "brain_size=planet",
+			"earth",
 		}, nil, planCmd)
 	})
 }


### PR DESCRIPTION
`init`, `destroy`, and `plan` all have a single optional `[DIR]` positional arg, e.g.:

```
❤ @up ➜  ~  terraform -help init   
Usage: terraform init [options] [DIR]
```