### PR TITLE
Add -detailed-exitcode option to Plan

### DIFF
--- a/tfexec/errors.go
+++ b/tfexec/errors.go
@@ -36,7 +36,7 @@ func parseError(err error, stderr string) error {
 				break
 			}
 		}
-		
+
 		return &ErrMissingVar{name}
 	case usageRegexp.MatchString(stderr):
 		return &ErrCLIUsage{stderr: stderr}
@@ -44,6 +44,8 @@ func parseError(err error, stderr string) error {
 		return &ErrNoInit{stderr: stderr}
 	case noConfigErrRegexp.MatchString(stderr):
 		return &ErrNoConfig{stderr: stderr}
+	case err.(*exec.ExitError).ProcessState.ExitCode() == 2:
+		return &ErrExitCodeTwo{stderr: err.Error()}
 	default:
 		return errors.New(stderr)
 	}

--- a/tfexec/errors.go
+++ b/tfexec/errors.go
@@ -44,8 +44,6 @@ func parseError(err error, stderr string) error {
 		return &ErrNoInit{stderr: stderr}
 	case noConfigErrRegexp.MatchString(stderr):
 		return &ErrNoConfig{stderr: stderr}
-	case err.(*exec.ExitError).ProcessState.ExitCode() == 2:
-		return &ErrExitCodeTwo{stderr: err.Error()}
 	default:
 		return errors.New(stderr)
 	}

--- a/tfexec/internal/e2etest/errors_test.go
+++ b/tfexec/internal/e2etest/errors_test.go
@@ -41,9 +41,9 @@ func TestMissingVar(t *testing.T) {
 		err := tf.Init(context.Background())
 		if err != nil {
 			t.Fatalf("err during init: %s", err)
-		} 
+		}
 
-		err = tf.Plan(context.Background())
+		_, err = tf.Plan(context.Background())
 		if err == nil {
 			t.Fatalf("expected error running Plan, none returned")
 		}
@@ -56,7 +56,7 @@ func TestMissingVar(t *testing.T) {
 			t.Fatalf("expected missing no_default, got %q", e.VariableName)
 		}
 
-		err = tf.Plan(context.Background(), tfexec.Var("no_default=foo"))
+		_, err = tf.Plan(context.Background(), tfexec.Var("no_default=foo"))
 		if err != nil {
 			t.Fatalf("expected no error, got %s", err)
 		}

--- a/tfexec/internal/e2etest/plan_test.go
+++ b/tfexec/internal/e2etest/plan_test.go
@@ -16,12 +16,12 @@ func TestPlan(t *testing.T) {
 			t.Fatalf("error running Init in test directory: %s", err)
 		}
 
-		ok, err := tf.Plan(context.Background())
+		hasChanges, err := tf.Plan(context.Background())
 		if err != nil {
 			t.Fatalf("error running Plan: %s", err)
 		}
-		if !ok {
-			t.Fatalf("expected: true, got: %t", ok)
+		if !hasChanges {
+			t.Fatalf("expected: true, got: %t", hasChanges)
 		}
 	})
 
@@ -37,12 +37,12 @@ func TestPlanWithState(t *testing.T) {
 			t.Fatalf("error running Init in test directory: %s", err)
 		}
 
-		ok, err := tf.Plan(context.Background())
+		hasChanges, err := tf.Plan(context.Background())
 		if err != nil {
 			t.Fatalf("error running Plan: %s", err)
 		}
-		if ok {
-			t.Fatalf("expected: false, got: %t", ok)
+		if hasChanges {
+			t.Fatalf("expected: false, got: %t", hasChanges)
 		}
 	})
 

--- a/tfexec/internal/e2etest/plan_test.go
+++ b/tfexec/internal/e2etest/plan_test.go
@@ -16,9 +16,33 @@ func TestPlan(t *testing.T) {
 			t.Fatalf("error running Init in test directory: %s", err)
 		}
 
-		err = tf.Plan(context.Background())
+		ok, err := tf.Plan(context.Background())
 		if err != nil {
 			t.Fatalf("error running Plan: %s", err)
+		}
+		if !ok {
+			t.Fatalf("expected: true, got: %t", ok)
+		}
+	})
+
+}
+
+func TestPlanWithState(t *testing.T) {
+	runTest(t, "basic_with_state", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+		if tfv.LessThan(version.Must(version.NewVersion("0.12.0"))) {
+			t.Skip("state file is not compatiable with Terraform 0.11")
+		}
+		err := tf.Init(context.Background())
+		if err != nil {
+			t.Fatalf("error running Init in test directory: %s", err)
+		}
+
+		ok, err := tf.Plan(context.Background())
+		if err != nil {
+			t.Fatalf("error running Plan: %s", err)
+		}
+		if ok {
+			t.Fatalf("expected: false, got: %t", ok)
 		}
 	})
 

--- a/tfexec/options.go
+++ b/tfexec/options.go
@@ -45,6 +45,14 @@ func Config(path string) *ConfigOption {
 	return &ConfigOption{path}
 }
 
+type DetailedExitCodeOption struct {
+	detailedExitCode bool
+}
+
+func DetailedExitCode(detailedExitCode bool) *DetailedExitCodeOption {
+	return &DetailedExitCodeOption{detailedExitCode}
+}
+
 type DirOption struct {
 	path string
 }

--- a/tfexec/options.go
+++ b/tfexec/options.go
@@ -45,14 +45,6 @@ func Config(path string) *ConfigOption {
 	return &ConfigOption{path}
 }
 
-type DetailedExitCodeOption struct {
-	detailedExitCode bool
-}
-
-func DetailedExitCode(detailedExitCode bool) *DetailedExitCodeOption {
-	return &DetailedExitCodeOption{detailedExitCode}
-}
-
 type DirOption struct {
 	path string
 }

--- a/tfexec/plan.go
+++ b/tfexec/plan.go
@@ -8,25 +8,27 @@ import (
 )
 
 type planConfig struct {
-	destroy     bool
-	dir         string
-	lock        bool
-	lockTimeout string
-	out         string
-	parallelism int
-	refresh     bool
-	state       string
-	targets     []string
-	vars        []string
-	varFile     string
+	destroy          bool
+	detailedExitCode bool
+	dir              string
+	lock             bool
+	lockTimeout      string
+	out              string
+	parallelism      int
+	refresh          bool
+	state            string
+	targets          []string
+	vars             []string
+	varFile          string
 }
 
 var defaultPlanOptions = planConfig{
-	destroy:     false,
-	lock:        true,
-	lockTimeout: "0s",
-	parallelism: 10,
-	refresh:     true,
+	destroy:          false,
+	detailedExitCode: false,
+	lock:             true,
+	lockTimeout:      "0s",
+	parallelism:      10,
+	refresh:          true,
 }
 
 type PlanOption interface {
@@ -73,6 +75,10 @@ func (opt *LockOption) configurePlan(conf *planConfig) {
 	conf.lock = opt.lock
 }
 
+func (opt *DetailedExitCodeOption) configurePlan(conf *planConfig) {
+	conf.detailedExitCode = opt.detailedExitCode
+}
+
 func (opt *DestroyFlagOption) configurePlan(conf *planConfig) {
 	conf.destroy = opt.destroy
 }
@@ -112,6 +118,9 @@ func (tf *Terraform) planCmd(ctx context.Context, opts ...PlanOption) *exec.Cmd 
 	// unary flags: pass if true
 	if c.destroy {
 		args = append(args, "-destroy")
+	}
+	if c.detailedExitCode {
+		args = append(args, "-detailed-exitcode")
 	}
 
 	// string slice opts: split into separate args

--- a/tfexec/plan_test.go
+++ b/tfexec/plan_test.go
@@ -27,6 +27,7 @@ func TestPlanCmd(t *testing.T) {
 			"plan",
 			"-no-color",
 			"-input=false",
+			"-detailed-exitcode",
 			"-lock-timeout=0s",
 			"-lock=true",
 			"-parallelism=10",
@@ -35,12 +36,13 @@ func TestPlanCmd(t *testing.T) {
 	})
 
 	t.Run("override all defaults", func(t *testing.T) {
-		planCmd := tf.planCmd(context.Background(), Destroy(true), DetailedExitCode(true), Lock(false), LockTimeout("22s"), Out("whale"), Parallelism(42), Refresh(false), State("marvin"), Target("zaphod"), Target("beeblebrox"), Var("android=paranoid"), Var("brain_size=planet"), VarFile("trillian"), Dir("earth"))
+		planCmd := tf.planCmd(context.Background(), Destroy(true), Lock(false), LockTimeout("22s"), Out("whale"), Parallelism(42), Refresh(false), State("marvin"), Target("zaphod"), Target("beeblebrox"), Var("android=paranoid"), Var("brain_size=planet"), VarFile("trillian"), Dir("earth"))
 
 		assertCmd(t, []string{
 			"plan",
 			"-no-color",
 			"-input=false",
+			"-detailed-exitcode",
 			"-lock-timeout=22s",
 			"-out=whale",
 			"-state=marvin",
@@ -49,7 +51,6 @@ func TestPlanCmd(t *testing.T) {
 			"-parallelism=42",
 			"-refresh=false",
 			"-destroy",
-			"-detailed-exitcode",
 			"-target=zaphod",
 			"-target=beeblebrox",
 			"-var", "android=paranoid",

--- a/tfexec/plan_test.go
+++ b/tfexec/plan_test.go
@@ -35,7 +35,7 @@ func TestPlanCmd(t *testing.T) {
 	})
 
 	t.Run("override all defaults", func(t *testing.T) {
-		planCmd := tf.planCmd(context.Background(), Destroy(true), Lock(false), LockTimeout("22s"), Out("whale"), Parallelism(42), Refresh(false), State("marvin"), Target("zaphod"), Target("beeblebrox"), Var("android=paranoid"), Var("brain_size=planet"), VarFile("trillian"), Dir("earth"))
+		planCmd := tf.planCmd(context.Background(), Destroy(true), DetailedExitCode(true), Lock(false), LockTimeout("22s"), Out("whale"), Parallelism(42), Refresh(false), State("marvin"), Target("zaphod"), Target("beeblebrox"), Var("android=paranoid"), Var("brain_size=planet"), VarFile("trillian"), Dir("earth"))
 
 		assertCmd(t, []string{
 			"plan",
@@ -49,6 +49,7 @@ func TestPlanCmd(t *testing.T) {
 			"-parallelism=42",
 			"-refresh=false",
 			"-destroy",
+			"-detailed-exitcode",
 			"-target=zaphod",
 			"-target=beeblebrox",
 			"-var", "android=paranoid",


### PR DESCRIPTION
This adds the `-detailed-exitcode` option to `tfexec.Plan()` and returns
a boolean detailing whether a plan diff is empty or non-empty.

This allows the caller to make decisions when the plan has changes.

```
hasChanges, err := tf.Plan(context.Background())
if err != nil {
  panic(err)
}
if hasChanges {
  // Do something when the plan has changes.
}
```