### PR TITLE
Add error for missing variable

### DIFF
--- a/tfexec/cmd.go
+++ b/tfexec/cmd.go
@@ -107,13 +107,13 @@ func (tf *Terraform) runTerraformCmd(cmd *exec.Cmd) error {
 
 	stdout := tf.stdout
 	if cmd.Stdout != nil {
-		stdout = io.MultiWriter(cmd.Stdout, stdout)
+		stdout = io.MultiWriter(stdout, cmd.Stdout)
 	}
 	cmd.Stdout = stdout
 
 	stderr := io.MultiWriter(&errBuf, tf.stderr)
 	if cmd.Stderr != nil {
-		stderr = io.MultiWriter(cmd.Stderr, stderr)
+		stderr = io.MultiWriter(stderr, cmd.Stderr)
 	}
 	cmd.Stderr = stderr
 

--- a/tfexec/internal/e2etest/errors_test.go
+++ b/tfexec/internal/e2etest/errors_test.go
@@ -35,3 +35,30 @@ func TestUnparsedError(t *testing.T) {
 		}
 	})
 }
+
+func TestMissingVar(t *testing.T) {
+	runTest(t, "var", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+		err := tf.Init(context.Background())
+		if err != nil {
+			t.Fatalf("err during init: %s", err)
+		} 
+
+		err = tf.Plan(context.Background())
+		if err == nil {
+			t.Fatalf("expected error running Plan, none returned")
+		}
+		var e *tfexec.ErrMissingVar
+		if !errors.As(err, &e) {
+			t.Fatalf("expected ErrMissingVar, got %T, %s", err, err)
+		}
+
+		if e.VariableName != "no_default" {
+			t.Fatalf("expected missing no_default, got %q", e.VariableName)
+		}
+
+		err = tf.Plan(context.Background(), tfexec.Var("no_default=foo"))
+		if err != nil {
+			t.Fatalf("expected no error, got %s", err)
+		}
+	})
+}

--- a/tfexec/internal/e2etest/testdata/var/main.tf
+++ b/tfexec/internal/e2etest/testdata/var/main.tf
@@ -1,0 +1,6 @@
+variable "default" {
+  default = "foo"
+}
+
+variable "no_default" {
+} 

--- a/tfexec/internal/e2etest/util_test.go
+++ b/tfexec/internal/e2etest/util_test.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/go-version"
@@ -62,7 +63,7 @@ func runTestVersions(t *testing.T, versions []string, fixtureName string, cb fun
 				}
 			}
 
-			var stdouterr bytes.Buffer
+			var stdouterr strings.Builder
 			tf.SetStdout(&stdouterr)
 			tf.SetStderr(&stdouterr)
 


### PR DESCRIPTION
This only tests plans, I assumed the error strings were the same, but probably wouldn't hurt to add an apply test as well.

I also resolved a minor issue where erroring commands were not in the test logging.