### PR TITLE
Set user agent appends for tests

### DIFF
--- a/tfexec/internal/e2etest/util_test.go
+++ b/tfexec/internal/e2etest/util_test.go
@@ -69,6 +69,8 @@ func runTestVersions(t *testing.T, versions []string, fixtureName string, cb fun
 				t.Fatal(err)
 			}
 
+			tf.SetAppendUserAgent("tfexec-e2etest")
+
 			runningVersion, _, err := tf.Version(context.Background(), false)
 			if err != nil {
 				t.Fatalf("unable to determin running version (expected %q): %s", tfv, err)

--- a/tfexec/internal/testutil/tfcache.go
+++ b/tfexec/internal/testutil/tfcache.go
@@ -18,6 +18,8 @@ const (
 	Latest013 = "0.13.0"
 )
 
+const appendUserAgent = "tfexec-testutil"
+
 type TFCache struct {
 	sync.Mutex
 
@@ -42,12 +44,13 @@ func (tf *TFCache) GitRef(t *testing.T, ref string) string {
 func (tf *TFCache) Version(t *testing.T, v string) string {
 	t.Helper()
 	return tf.find(t, "v:"+v, func(dir string) tfinstall.ExecPathFinder {
-		return tfinstall.ExactVersion(v, dir)
+		f := tfinstall.ExactVersion(v, dir)
+		f.UserAgent = appendUserAgent
+		return f
 	})
 }
 
 func (tf *TFCache) find(t *testing.T, key string, finder func(dir string) tfinstall.ExecPathFinder) string {
-
 	t.Helper()
 
 	if tf.dir == "" {
@@ -58,29 +61,30 @@ func (tf *TFCache) find(t *testing.T, key string, finder func(dir string) tfinst
 	tf.Lock()
 	defer tf.Unlock()
 
-	path, ok := tf.execs[key]
-	if !ok {
-		keyDir := key
-		keyDir = strings.ReplaceAll(keyDir, ":", "-")
-		keyDir = strings.ReplaceAll(keyDir, "/", "-")
-
-		dir := filepath.Join(tf.dir, keyDir)
-
-		t.Logf("caching exec %q in dir %q", key, dir)
-
-		err := os.MkdirAll(dir, 0777)
-		if err != nil {
-			// panic instead of t.fatal as this is going to affect all downstream tests reusing the cache entry
-			panic(fmt.Sprintf("unable to mkdir %q: %s", dir, err))
-		}
-
-		path, err = tfinstall.Find(context.Background(), finder(dir))
-		if err != nil {
-			// panic instead of t.fatal as this is going to affect all downstream tests reusing the cache entry
-			panic(fmt.Sprintf("error installing terraform %q: %s", key, err))
-		}
-		tf.execs[key] = path
+	if path, ok := tf.execs[key]; ok {
+		return path
 	}
+
+	keyDir := key
+	keyDir = strings.ReplaceAll(keyDir, ":", "-")
+	keyDir = strings.ReplaceAll(keyDir, "/", "-")
+
+	dir := filepath.Join(tf.dir, keyDir)
+
+	t.Logf("caching exec %q in dir %q", key, dir)
+
+	err := os.MkdirAll(dir, 0777)
+	if err != nil {
+		// panic instead of t.fatal as this is going to affect all downstream tests reusing the cache entry
+		panic(fmt.Sprintf("unable to mkdir %q: %s", dir, err))
+	}
+
+	path, err := tfinstall.Find(context.Background(), finder(dir))
+	if err != nil {
+		// panic instead of t.fatal as this is going to affect all downstream tests reusing the cache entry
+		panic(fmt.Sprintf("error installing terraform %q: %s", key, err))
+	}
+	tf.execs[key] = path
 
 	return path
 }

--- a/tfinstall/download.go
+++ b/tfinstall/download.go
@@ -25,7 +25,7 @@ func ensureInstallDir(installDir string) (string, error) {
 	return installDir, nil
 }
 
-func downloadWithVerification(ctx context.Context, tfVersion string, installDir string) (string, error) {
+func downloadWithVerification(ctx context.Context, tfVersion string, installDir string, appendUserAgent string) (string, error) {
 	osName := runtime.GOOS
 	archName := runtime.GOARCH
 
@@ -37,7 +37,7 @@ func downloadWithVerification(ctx context.Context, tfVersion string, installDir 
 
 	httpGetter := &getter.HttpGetter{
 		Netrc:  true,
-		Client: newHTTPClient(),
+		Client: newHTTPClient(appendUserAgent),
 	}
 	client := getter.Client{
 		Ctx: ctx,

--- a/tfinstall/exact_version.go
+++ b/tfinstall/exact_version.go
@@ -9,6 +9,8 @@ import (
 type ExactVersionOption struct {
 	tfVersion  string
 	installDir string
+
+	UserAgent string
 }
 
 var _ ExecPathFinder = &ExactVersionOption{}
@@ -29,5 +31,5 @@ func (opt *ExactVersionOption) ExecPath(ctx context.Context) (string, error) {
 		return "", err
 	}
 
-	return downloadWithVerification(ctx, opt.tfVersion, opt.installDir)
+	return downloadWithVerification(ctx, opt.tfVersion, opt.installDir, opt.UserAgent)
 }

--- a/tfinstall/http.go
+++ b/tfinstall/http.go
@@ -23,8 +23,8 @@ func (rt *userAgentRoundTripper) RoundTrip(req *http.Request) (*http.Response, e
 	return rt.inner.RoundTrip(req)
 }
 
-func newHTTPClient() *http.Client {
-	appendUA := os.Getenv("TF_APPEND_USER_AGENT")
+func newHTTPClient(appendUA string) *http.Client {
+	appendUA = strings.TrimSpace(appendUA + " " + os.Getenv("TF_APPEND_USER_AGENT"))
 	userAgent := strings.TrimSpace(fmt.Sprintf("HashiCorp-tfinstall/%s %s", intversion.ModuleVersion(), appendUA))
 
 	cli := cleanhttp.DefaultPooledClient()

--- a/tfinstall/latest_version.go
+++ b/tfinstall/latest_version.go
@@ -10,6 +10,8 @@ import (
 type LatestVersionOption struct {
 	forceCheckpoint bool
 	installDir      string
+
+	UserAgent string
 }
 
 var _ ExecPathFinder = &LatestVersionOption{}
@@ -29,7 +31,7 @@ func (opt *LatestVersionOption) ExecPath(ctx context.Context) (string, error) {
 		return "", err
 	}
 
-	return downloadWithVerification(ctx, v, opt.installDir)
+	return downloadWithVerification(ctx, v, opt.installDir, opt.UserAgent)
 }
 
 func latestVersion(forceCheckpoint bool) (string, error) {


### PR DESCRIPTION
Since we are starting to download a ton of terraform binaries in automation, I wanted to make sure we are appropriately flagging those downloads as part of our automation.