### PR TITLE
add ReattachOption

### DIFF
--- a/tfexec/apply_test.go
+++ b/tfexec/apply_test.go
@@ -21,7 +21,7 @@ func TestApplyCmd(t *testing.T) {
 	tf.SetEnv(map[string]string{})
 
 	t.Run("basic", func(t *testing.T) {
-		applyCmd := tf.applyCmd(context.Background(),
+		applyCmd, err := tf.applyCmd(context.Background(),
 			Backup("testbackup"),
 			LockTimeout("200s"),
 			State("teststate"),
@@ -37,6 +37,9 @@ func TestApplyCmd(t *testing.T) {
 			Var("var2=bar"),
 			DirOrPlan("testfile"),
 		)
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		assertCmd(t, []string{
 			"apply",

--- a/tfexec/cmd.go
+++ b/tfexec/cmd.go
@@ -114,12 +114,20 @@ func (tf *Terraform) buildEnv(mergeEnv map[string]string) []string {
 	// force usage of workspace methods for switching
 	env[workspaceEnvVar] = ""
 
+	if tf.disablePluginTLS {
+		env[disablePluginTLSEnvVar] = "1"
+	}
+
+	if tf.skipProviderVerify {
+		env[skipProviderVerifyEnvVar] = "1"
+	}
+
 	return envSlice(env)
 }
 
-func (tf *Terraform) buildTerraformCmd(ctx context.Context, args ...string) *exec.Cmd {
+func (tf *Terraform) buildTerraformCmd(ctx context.Context, mergeEnv map[string]string, args ...string) *exec.Cmd {
 	cmd := exec.CommandContext(ctx, tf.execPath, args...)
-	cmd.Env = tf.buildEnv(nil)
+	cmd.Env = tf.buildEnv(mergeEnv)
 	cmd.Dir = tf.workingDir
 
 	tf.logger.Printf("[INFO] running Terraform command: %s", cmdString(cmd))

--- a/tfexec/cmd.go
+++ b/tfexec/cmd.go
@@ -15,14 +15,16 @@ import (
 )
 
 const (
-	checkpointDisableEnvVar = "CHECKPOINT_DISABLE"
-	logEnvVar               = "TF_LOG"
-	inputEnvVar             = "TF_INPUT"
-	automationEnvVar        = "TF_IN_AUTOMATION"
-	logPathEnvVar           = "TF_LOG_PATH"
-	reattachEnvVar          = "TF_REATTACH_PROVIDERS"
-	appendUserAgentEnvVar   = "TF_APPEND_USER_AGENT"
-	workspaceEnvVar         = "TF_WORKSPACE"
+	checkpointDisableEnvVar  = "CHECKPOINT_DISABLE"
+	logEnvVar                = "TF_LOG"
+	inputEnvVar              = "TF_INPUT"
+	automationEnvVar         = "TF_IN_AUTOMATION"
+	logPathEnvVar            = "TF_LOG_PATH"
+	reattachEnvVar           = "TF_REATTACH_PROVIDERS"
+	appendUserAgentEnvVar    = "TF_APPEND_USER_AGENT"
+	workspaceEnvVar          = "TF_WORKSPACE"
+	disablePluginTLSEnvVar   = "TF_DISABLE_PLUGIN_TLS"
+	skipProviderVerifyEnvVar = "TF_SKIP_PROVIDER_VERIFY"
 
 	varEnvVarPrefix = "TF_VAR_"
 )
@@ -35,6 +37,8 @@ var prohibitedEnvVars = []string{
 	reattachEnvVar,
 	appendUserAgentEnvVar,
 	workspaceEnvVar,
+	disablePluginTLSEnvVar,
+	skipProviderVerifyEnvVar,
 }
 
 func envMap(environ []string) map[string]string {

--- a/tfexec/destroy_test.go
+++ b/tfexec/destroy_test.go
@@ -21,7 +21,10 @@ func TestDestroyCmd(t *testing.T) {
 	tf.SetEnv(map[string]string{})
 
 	t.Run("defaults", func(t *testing.T) {
-		destroyCmd := tf.destroyCmd(context.Background())
+		destroyCmd, err := tf.destroyCmd(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		assertCmd(t, []string{
 			"destroy",
@@ -36,7 +39,10 @@ func TestDestroyCmd(t *testing.T) {
 	})
 
 	t.Run("override all defaults", func(t *testing.T) {
-		destroyCmd := tf.destroyCmd(context.Background(), Backup("testbackup"), LockTimeout("200s"), State("teststate"), StateOut("teststateout"), VarFile("testvarfile"), Lock(false), Parallelism(99), Refresh(false), Target("target1"), Target("target2"), Var("var1=foo"), Var("var2=bar"), Dir("destroydir"))
+		destroyCmd, err := tf.destroyCmd(context.Background(), Backup("testbackup"), LockTimeout("200s"), State("teststate"), StateOut("teststateout"), VarFile("testvarfile"), Lock(false), Parallelism(99), Refresh(false), Target("target1"), Target("target2"), Var("var1=foo"), Var("var2=bar"), Dir("destroydir"))
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		assertCmd(t, []string{
 			"destroy",

--- a/tfexec/import_test.go
+++ b/tfexec/import_test.go
@@ -21,7 +21,10 @@ func TestImportCmd(t *testing.T) {
 	tf.SetEnv(map[string]string{})
 
 	t.Run("defaults", func(t *testing.T) {
-		importCmd := tf.importCmd(context.Background(), "my-addr", "my-id")
+		importCmd, err := tf.importCmd(context.Background(), "my-addr", "my-id")
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		assertCmd(t, []string{
 			"import",
@@ -35,7 +38,7 @@ func TestImportCmd(t *testing.T) {
 	})
 
 	t.Run("override all defaults", func(t *testing.T) {
-		importCmd := tf.importCmd(context.Background(), "my-addr2", "my-id2",
+		importCmd, err := tf.importCmd(context.Background(), "my-addr2", "my-id2",
 			Backup("testbackup"),
 			LockTimeout("200s"),
 			State("teststate"),
@@ -46,6 +49,9 @@ func TestImportCmd(t *testing.T) {
 			Var("var2=bar"),
 			AllowMissingConfig(true),
 		)
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		assertCmd(t, []string{
 			"import",

--- a/tfexec/init.go
+++ b/tfexec/init.go
@@ -17,6 +17,7 @@ type initConfig struct {
 	lock          bool
 	lockTimeout   string
 	pluginDir     []string
+	reattachInfo  ReattachInfo
 	reconfigure   bool
 	upgrade       bool
 	verifyPlugins bool
@@ -75,6 +76,10 @@ func (opt *PluginDirOption) configureInit(conf *initConfig) {
 	conf.pluginDir = append(conf.pluginDir, opt.pluginDir)
 }
 
+func (opt *ReattachOption) configureInit(conf *initConfig) {
+	conf.reattachInfo = opt.info
+}
+
 func (opt *ReconfigureOption) configureInit(conf *initConfig) {
 	conf.reconfigure = opt.reconfigure
 }
@@ -89,10 +94,14 @@ func (opt *VerifyPluginsOption) configureInit(conf *initConfig) {
 
 // Init represents the terraform init subcommand.
 func (tf *Terraform) Init(ctx context.Context, opts ...InitOption) error {
-	return tf.runTerraformCmd(tf.initCmd(ctx, opts...))
+	cmd, err := tf.initCmd(ctx, opts...)
+	if err != nil {
+		return err
+	}
+	return tf.runTerraformCmd(cmd)
 }
 
-func (tf *Terraform) initCmd(ctx context.Context, opts ...InitOption) *exec.Cmd {
+func (tf *Terraform) initCmd(ctx context.Context, opts ...InitOption) (*exec.Cmd, error) {
 	c := defaultInitOptions
 
 	for _, o := range opts {
@@ -139,5 +148,14 @@ func (tf *Terraform) initCmd(ctx context.Context, opts ...InitOption) *exec.Cmd 
 		args = append(args, c.dir)
 	}
 
-	return tf.buildTerraformCmd(ctx, args...)
+	mergeEnv := map[string]string{}
+	if c.reattachInfo != nil {
+		reattachStr, err := c.reattachInfo.marshalString()
+		if err != nil {
+			return nil, err
+		}
+		mergeEnv[reattachEnvVar] = reattachStr
+	}
+
+	return tf.buildTerraformCmd(ctx, mergeEnv, args...), nil
 }

--- a/tfexec/init_test.go
+++ b/tfexec/init_test.go
@@ -22,7 +22,7 @@ func TestInitCmd(t *testing.T) {
 
 	t.Run("defaults", func(t *testing.T) {
 		// defaults
-		initCmd := tf.initCmd(context.Background())
+		initCmd, err := tf.initCmd(context.Background())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -43,7 +43,10 @@ func TestInitCmd(t *testing.T) {
 	})
 
 	t.Run("override all defaults", func(t *testing.T) {
-		initCmd := tf.initCmd(context.Background(), Backend(false), BackendConfig("confpath1"), BackendConfig("confpath2"), FromModule("testsource"), Get(false), GetPlugins(false), Lock(false), LockTimeout("999s"), PluginDir("testdir1"), PluginDir("testdir2"), Reconfigure(true), Upgrade(true), VerifyPlugins(false), Dir("initdir"))
+		initCmd, err := tf.initCmd(context.Background(), Backend(false), BackendConfig("confpath1"), BackendConfig("confpath2"), FromModule("testsource"), Get(false), GetPlugins(false), Lock(false), LockTimeout("999s"), PluginDir("testdir1"), PluginDir("testdir2"), Reconfigure(true), Upgrade(true), VerifyPlugins(false), Dir("initdir"))
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		assertCmd(t, []string{
 			"init",

--- a/tfexec/options.go
+++ b/tfexec/options.go
@@ -1,5 +1,9 @@
 package tfexec
 
+import (
+	"encoding/json"
+)
+
 // AllowMissingConfigOption represents the -allow-missing-config flag.
 type AllowMissingConfigOption struct {
 	allowMissingConfig bool
@@ -170,6 +174,39 @@ type PluginDirOption struct {
 
 func PluginDir(pluginDir string) *PluginDirOption {
 	return &PluginDirOption{pluginDir}
+}
+
+type ReattachInfo map[string]ReattachConfig
+
+// ReattachConfig holds the information Terraform needs to be able to attach
+// itself to a provider process, so it can drive the process.
+type ReattachConfig struct {
+	Protocol string
+	Pid      int
+	Test     bool
+	Addr     ReattachConfigAddr
+}
+
+// ReattachConfigAddr is a JSON-encoding friendly version of net.Addr.
+type ReattachConfigAddr struct {
+	Network string
+	String  string
+}
+
+type ReattachOption struct {
+	info ReattachInfo
+}
+
+func (info ReattachInfo) marshalString() (string, error) {
+	reattachStr, err := json.Marshal(info)
+	if err != nil {
+		return "", err
+	}
+	return string(reattachStr), nil
+}
+
+func Reattach(info ReattachInfo) *ReattachOption {
+	return &ReattachOption{info}
 }
 
 type ReconfigureOption struct {

--- a/tfexec/output.go
+++ b/tfexec/output.go
@@ -59,5 +59,5 @@ func (tf *Terraform) outputCmd(ctx context.Context, opts ...OutputOption) *exec.
 		args = append(args, "-state="+c.state)
 	}
 
-	return tf.buildTerraformCmd(ctx, args...)
+	return tf.buildTerraformCmd(ctx, nil, args...)
 }

--- a/tfexec/plan_test.go
+++ b/tfexec/plan_test.go
@@ -21,7 +21,10 @@ func TestPlanCmd(t *testing.T) {
 	tf.SetEnv(map[string]string{})
 
 	t.Run("defaults", func(t *testing.T) {
-		planCmd := tf.planCmd(context.Background())
+		planCmd, err := tf.planCmd(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		assertCmd(t, []string{
 			"plan",
@@ -36,7 +39,10 @@ func TestPlanCmd(t *testing.T) {
 	})
 
 	t.Run("override all defaults", func(t *testing.T) {
-		planCmd := tf.planCmd(context.Background(), Destroy(true), Lock(false), LockTimeout("22s"), Out("whale"), Parallelism(42), Refresh(false), State("marvin"), Target("zaphod"), Target("beeblebrox"), Var("android=paranoid"), Var("brain_size=planet"), VarFile("trillian"), Dir("earth"))
+		planCmd, err := tf.planCmd(context.Background(), Destroy(true), Lock(false), LockTimeout("22s"), Out("whale"), Parallelism(42), Refresh(false), State("marvin"), Target("zaphod"), Target("beeblebrox"), Var("android=paranoid"), Var("brain_size=planet"), VarFile("trillian"), Dir("earth"))
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		assertCmd(t, []string{
 			"plan",

--- a/tfexec/providers_schema.go
+++ b/tfexec/providers_schema.go
@@ -29,5 +29,5 @@ func (tf *Terraform) providersSchemaCmd(ctx context.Context, args ...string) *ex
 	allArgs := []string{"providers", "schema", "-json", "-no-color"}
 	allArgs = append(allArgs, args...)
 
-	return tf.buildTerraformCmd(ctx, allArgs...)
+	return tf.buildTerraformCmd(ctx, nil, allArgs...)
 }

--- a/tfexec/refresh.go
+++ b/tfexec/refresh.go
@@ -7,15 +7,16 @@ import (
 )
 
 type refreshConfig struct {
-	backup      string
-	dir         string
-	lock        bool
-	lockTimeout string
-	state       string
-	stateOut    string
-	targets     []string
-	vars        []string
-	varFiles    []string
+	backup       string
+	dir          string
+	lock         bool
+	lockTimeout  string
+	reattachInfo ReattachInfo
+	state        string
+	stateOut     string
+	targets      []string
+	vars         []string
+	varFiles     []string
 }
 
 var defaultRefreshOptions = refreshConfig{
@@ -44,6 +45,10 @@ func (opt *LockTimeoutOption) configureRefresh(conf *refreshConfig) {
 	conf.lockTimeout = opt.timeout
 }
 
+func (opt *ReattachOption) configureRefresh(conf *refreshConfig) {
+	conf.reattachInfo = opt.info
+}
+
 func (opt *StateOption) configureRefresh(conf *refreshConfig) {
 	conf.state = opt.path
 }
@@ -66,10 +71,14 @@ func (opt *VarFileOption) configureRefresh(conf *refreshConfig) {
 
 // Refresh represents the terraform refresh subcommand.
 func (tf *Terraform) Refresh(ctx context.Context, opts ...RefreshCmdOption) error {
-	return tf.runTerraformCmd(tf.refreshCmd(ctx, opts...))
+	cmd, err := tf.refreshCmd(ctx, opts...)
+	if err != nil {
+		return err
+	}
+	return tf.runTerraformCmd(cmd)
 }
 
-func (tf *Terraform) refreshCmd(ctx context.Context, opts ...RefreshCmdOption) *exec.Cmd {
+func (tf *Terraform) refreshCmd(ctx context.Context, opts ...RefreshCmdOption) (*exec.Cmd, error) {
 	c := defaultRefreshOptions
 
 	for _, o := range opts {
@@ -115,5 +124,14 @@ func (tf *Terraform) refreshCmd(ctx context.Context, opts ...RefreshCmdOption) *
 		args = append(args, c.dir)
 	}
 
-	return tf.buildTerraformCmd(ctx, args...)
+	mergeEnv := map[string]string{}
+	if c.reattachInfo != nil {
+		reattachStr, err := c.reattachInfo.marshalString()
+		if err != nil {
+			return nil, err
+		}
+		mergeEnv[reattachEnvVar] = reattachStr
+	}
+
+	return tf.buildTerraformCmd(ctx, mergeEnv, args...), nil
 }

--- a/tfexec/refresh_test.go
+++ b/tfexec/refresh_test.go
@@ -21,7 +21,10 @@ func TestRefreshCmd(t *testing.T) {
 	tf.SetEnv(map[string]string{})
 
 	t.Run("defaults", func(t *testing.T) {
-		refreshCmd := tf.refreshCmd(context.Background())
+		refreshCmd, err := tf.refreshCmd(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		assertCmd(t, []string{
 			"refresh",
@@ -33,7 +36,10 @@ func TestRefreshCmd(t *testing.T) {
 	})
 
 	t.Run("override all defaults", func(t *testing.T) {
-		refreshCmd := tf.refreshCmd(context.Background(), Backup("testbackup"), LockTimeout("200s"), State("teststate"), StateOut("teststateout"), VarFile("testvarfile"), Lock(false), Target("target1"), Target("target2"), Var("var1=foo"), Var("var2=bar"), Dir("refreshdir"))
+		refreshCmd, err := tf.refreshCmd(context.Background(), Backup("testbackup"), LockTimeout("200s"), State("teststate"), StateOut("teststateout"), VarFile("testvarfile"), Lock(false), Target("target1"), Target("target2"), Var("var1=foo"), Var("var2=bar"), Dir("refreshdir"))
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		assertCmd(t, []string{
 			"refresh",

--- a/tfexec/show_test.go
+++ b/tfexec/show_test.go
@@ -21,7 +21,7 @@ func TestShowCmd(t *testing.T) {
 	tf.SetEnv(map[string]string{})
 
 	// defaults
-	showCmd := tf.showCmd(context.Background())
+	showCmd := tf.showCmd(context.Background(), nil)
 
 	assertCmd(t, []string{
 		"show",
@@ -42,7 +42,7 @@ func TestShowStateFileCmd(t *testing.T) {
 	// empty env, to avoid environ mismatch in testing
 	tf.SetEnv(map[string]string{})
 
-	showCmd := tf.showCmd(context.Background(), "statefilepath")
+	showCmd := tf.showCmd(context.Background(), nil, "statefilepath")
 
 	assertCmd(t, []string{
 		"show",
@@ -64,7 +64,7 @@ func TestShowPlanFileCmd(t *testing.T) {
 	// empty env, to avoid environ mismatch in testing
 	tf.SetEnv(map[string]string{})
 
-	showCmd := tf.showCmd(context.Background(), "planfilepath")
+	showCmd := tf.showCmd(context.Background(), nil, "planfilepath")
 
 	assertCmd(t, []string{
 		"show",

--- a/tfexec/terraform.go
+++ b/tfexec/terraform.go
@@ -1,6 +1,7 @@
 package tfexec
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -32,11 +33,15 @@ type printfer interface {
 //  - TF_LOG
 //  - TF_LOG_PATH
 //  - TF_REATTACH_PROVIDERS
+//  - TF_DISABLE_PLUGIN_TLS
+//  - TF_SKIP_PROVIDER_VERIFY
 type Terraform struct {
-	execPath        string
-	workingDir      string
-	appendUserAgent string
-	env             map[string]string
+	execPath           string
+	workingDir         string
+	appendUserAgent    string
+	disablePluginTLS   bool
+	skipProviderVerify bool
+	env                map[string]string
 
 	stdout  io.Writer
 	stderr  io.Writer
@@ -125,8 +130,27 @@ func (tf *Terraform) SetLogPath(path string) error {
 
 // SetAppendUserAgent sets the TF_APPEND_USER_AGENT environment variable for
 // Terraform CLI execution.
-func (tf *Terraform) SetAppendUserAgent(ua string) {
+func (tf *Terraform) SetAppendUserAgent(ua string) error {
 	tf.appendUserAgent = ua
+	return nil
+}
+
+// SetDisablePluginTLS sets the TF_DISABLE_PLUGIN_TLS environment variable for
+// Terraform CLI execution.
+func (tf *Terraform) SetDisablePluginTLS(disabled bool) error {
+	tf.disablePluginTLS = disabled
+	return nil
+}
+
+// SetSkipProviderVerify sets the TF_SKIP_PROVIDER_VERIFY environment variable
+// for Terraform CLI execution. This is no longer used in 0.13.0 and greater.
+func (tf *Terraform) SetSkipProviderVerify(skip bool) error {
+	err := tf.compatible(context.Background(), nil, tf0_13_0)
+	if err != nil {
+		return err
+	}
+	tf.skipProviderVerify = skip
+	return nil
 }
 
 // WorkingDir returns the working directory for Terraform.

--- a/tfexec/terraform_test.go
+++ b/tfexec/terraform_test.go
@@ -85,7 +85,10 @@ func TestCheckpointDisablePropagation(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		initCmd := tf.initCmd(context.Background())
+		initCmd, err := tf.initCmd(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		assertCmd(t, []string{
 			"init",
@@ -114,7 +117,10 @@ func TestCheckpointDisablePropagation(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		initCmd := tf.initCmd(context.Background())
+		initCmd, err := tf.initCmd(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		assertCmd(t, []string{
 			"init",

--- a/tfexec/version.go
+++ b/tfexec/version.go
@@ -38,7 +38,7 @@ func (tf *Terraform) version(ctx context.Context) (*version.Version, map[string]
 	// TODO: 0.13.0-beta2? and above supports a `-json` on the version command, should add support
 	// for that here and fallback to string parsing
 
-	versionCmd := tf.buildTerraformCmd(ctx, "version")
+	versionCmd := tf.buildTerraformCmd(ctx, nil, "version")
 
 	var outBuf bytes.Buffer
 	versionCmd.Stdout = &outBuf

--- a/tfexec/version.go
+++ b/tfexec/version.go
@@ -13,6 +13,7 @@ import (
 
 var (
 	tf0_12_0 = version.Must(version.NewVersion("0.12.0"))
+	tf0_13_0 = version.Must(version.NewVersion("0.13.0"))
 )
 
 // Version returns structured output from the terraform version command including both the Terraform CLI version

--- a/tfexec/workspace_list.go
+++ b/tfexec/workspace_list.go
@@ -9,7 +9,7 @@ import (
 // WorkspaceList represents the workspace list subcommand to the Terraform CLI.
 func (tf *Terraform) WorkspaceList(ctx context.Context) ([]string, string, error) {
 	// TODO: [DIR] param option
-	wlCmd := tf.buildTerraformCmd(ctx, "workspace", "list", "-no-color")
+	wlCmd := tf.buildTerraformCmd(ctx, nil, "workspace", "list", "-no-color")
 
 	var outBuf bytes.Buffer
 	wlCmd.Stdout = &outBuf

--- a/tfexec/workspace_new.go
+++ b/tfexec/workspace_new.go
@@ -77,7 +77,7 @@ func (tf *Terraform) workspaceNewCmd(ctx context.Context, workspace string, opts
 
 	args = append(args, workspace)
 
-	cmd := tf.buildTerraformCmd(ctx, args...)
+	cmd := tf.buildTerraformCmd(ctx, nil, args...)
 
 	return cmd, nil
 }

--- a/tfexec/workspace_select.go
+++ b/tfexec/workspace_select.go
@@ -6,5 +6,5 @@ import "context"
 func (tf *Terraform) WorkspaceSelect(ctx context.Context, workspace string) error {
 	// TODO: [DIR] param option
 
-	return tf.runTerraformCmd(tf.buildTerraformCmd(ctx, "workspace", "select", "-no-color", workspace))
+	return tf.runTerraformCmd(tf.buildTerraformCmd(ctx, nil, "workspace", "select", "-no-color", workspace))
 }


### PR DESCRIPTION
Binary testing reattach functionality requires the `TF_PROVIDERS_REATTACH` env var to be present in the environment in which the Terraform CLI is run. In normal usage, such as in terraform-plugin-test, the value of this env var will change during the lifetime of a `*Terraform`. We therefore provide a way of setting the reattach info string on every relevant Terraform CLI command as if it is an option.