### PR TITLE
fmt: Gate formatting command on 0.7.7

### DIFF
--- a/tfexec/errors.go
+++ b/tfexec/errors.go
@@ -130,13 +130,8 @@ func (e *ErrVersionMismatch) Error() string {
 }
 
 func (e *ErrVersionMismatch) Is(target error) bool {
-	err, ok := target.(*ErrVersionMismatch)
-	if !ok {
-		return false
-	}
-	return err.Actual == e.Actual &&
-		err.MaxExclusive == e.MaxExclusive &&
-		err.MinInclusive == e.MinInclusive
+	_, ok := target.(*ErrVersionMismatch)
+	return ok
 }
 
 type ErrNoInit struct {

--- a/tfexec/errors.go
+++ b/tfexec/errors.go
@@ -129,6 +129,16 @@ func (e *ErrVersionMismatch) Error() string {
 	return fmt.Sprintf("unexpected version %s (min: %s, max: %s)", e.Actual, e.MinInclusive, e.MaxExclusive)
 }
 
+func (e *ErrVersionMismatch) Is(target error) bool {
+	err, ok := target.(*ErrVersionMismatch)
+	if !ok {
+		return false
+	}
+	return err.Actual == e.Actual &&
+		err.MaxExclusive == e.MaxExclusive &&
+		err.MinInclusive == e.MinInclusive
+}
+
 type ErrNoInit struct {
 	stderr string
 }

--- a/tfexec/errors.go
+++ b/tfexec/errors.go
@@ -129,11 +129,6 @@ func (e *ErrVersionMismatch) Error() string {
 	return fmt.Sprintf("unexpected version %s (min: %s, max: %s)", e.Actual, e.MinInclusive, e.MaxExclusive)
 }
 
-func (e *ErrVersionMismatch) Is(target error) bool {
-	_, ok := target.(*ErrVersionMismatch)
-	return ok
-}
-
 type ErrNoInit struct {
 	stderr string
 }

--- a/tfexec/fmt.go
+++ b/tfexec/fmt.go
@@ -121,6 +121,11 @@ func (tf *Terraform) FormatCheck(ctx context.Context, opts ...FormatOption) (boo
 }
 
 func (tf *Terraform) formatCmd(ctx context.Context, args []string, opts ...FormatOption) (*exec.Cmd, error) {
+	err := tf.compatible(ctx, tf0_7_7, nil)
+	if err != nil {
+		return nil, fmt.Errorf("fmt was first introduced in Terraform 0.7.7: %w", err)
+	}
+
 	c := defaultFormatConfig
 
 	for _, o := range opts {

--- a/tfexec/fmt_test.go
+++ b/tfexec/fmt_test.go
@@ -25,12 +25,8 @@ func TestFormat(t *testing.T) {
 			t.Fatal("expected old version to fail")
 		}
 
-		expectedErr := &ErrVersionMismatch{
-			Actual:       "0.7.6",
-			MinInclusive: "0.7.7",
-			MaxExclusive: "-",
-		}
-		if !errors.Is(err, expectedErr) {
+		var expectedErr *ErrVersionMismatch
+		if !errors.As(err, &expectedErr) {
 			t.Fatalf("error doesn't match: %#v", err)
 		}
 	})

--- a/tfexec/version.go
+++ b/tfexec/version.go
@@ -12,6 +12,7 @@ import (
 )
 
 var (
+	tf0_7_7  = version.Must(version.NewVersion("0.7.7"))
 	tf0_12_0 = version.Must(version.NewVersion("0.12.0"))
 	tf0_13_0 = version.Must(version.NewVersion("0.13.0"))
 )


### PR DESCRIPTION
This is mostly a UX enhancement which is already built into LS, so this is to help ease the transition.
