### PR TITLE
Enrich errors caused by context cancellation

### DIFF
--- a/tfexec/apply.go
+++ b/tfexec/apply.go
@@ -91,7 +91,7 @@ func (tf *Terraform) Apply(ctx context.Context, opts ...ApplyOption) error {
 	if err != nil {
 		return err
 	}
-	return tf.runTerraformCmd(cmd)
+	return tf.runTerraformCmd(ctx, cmd)
 }
 
 func (tf *Terraform) applyCmd(ctx context.Context, opts ...ApplyOption) (*exec.Cmd, error) {

--- a/tfexec/cmd.go
+++ b/tfexec/cmd.go
@@ -135,11 +135,11 @@ func (tf *Terraform) buildTerraformCmd(ctx context.Context, mergeEnv map[string]
 	return cmd
 }
 
-func (tf *Terraform) runTerraformCmdJSON(cmd *exec.Cmd, v interface{}) error {
+func (tf *Terraform) runTerraformCmdJSON(ctx context.Context, cmd *exec.Cmd, v interface{}) error {
 	var outbuf = bytes.Buffer{}
 	cmd.Stdout = mergeWriters(cmd.Stdout, &outbuf)
 
-	err := tf.runTerraformCmd(cmd)
+	err := tf.runTerraformCmd(ctx, cmd)
 	if err != nil {
 		return err
 	}
@@ -147,7 +147,7 @@ func (tf *Terraform) runTerraformCmdJSON(cmd *exec.Cmd, v interface{}) error {
 	return json.Unmarshal(outbuf.Bytes(), v)
 }
 
-func (tf *Terraform) runTerraformCmd(cmd *exec.Cmd) error {
+func (tf *Terraform) runTerraformCmd(ctx context.Context, cmd *exec.Cmd) error {
 	var errBuf strings.Builder
 
 	cmd.Stdout = mergeWriters(cmd.Stdout, tf.stdout)
@@ -155,7 +155,7 @@ func (tf *Terraform) runTerraformCmd(cmd *exec.Cmd) error {
 
 	err := cmd.Run()
 	if err != nil {
-		return tf.decodeError(cmd, err, errBuf.String())
+		return tf.decodeError(ctx, cmd, err, errBuf.String())
 	}
 	return nil
 }

--- a/tfexec/cmd.go
+++ b/tfexec/cmd.go
@@ -155,7 +155,7 @@ func (tf *Terraform) runTerraformCmd(cmd *exec.Cmd) error {
 
 	err := cmd.Run()
 	if err != nil {
-		return tf.parseError(err, errBuf.String())
+		return tf.decodeError(cmd, err, errBuf.String())
 	}
 	return nil
 }

--- a/tfexec/destroy.go
+++ b/tfexec/destroy.go
@@ -92,7 +92,7 @@ func (tf *Terraform) Destroy(ctx context.Context, opts ...DestroyOption) error {
 	if err != nil {
 		return err
 	}
-	return tf.runTerraformCmd(cmd)
+	return tf.runTerraformCmd(ctx, cmd)
 }
 
 func (tf *Terraform) destroyCmd(ctx context.Context, opts ...DestroyOption) (*exec.Cmd, error) {

--- a/tfexec/errors.go
+++ b/tfexec/errors.go
@@ -2,7 +2,6 @@ package tfexec
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os/exec"
 	"regexp"
@@ -215,30 +214,4 @@ type ExitError struct {
 
 func (e *ExitError) Unwrap() error {
 	return e.err
-}
-
-func (e *ExitError) Error() string {
-	var out string
-	ee, ok := e.err.(*exec.ExitError)
-	if ok {
-		out = fmt.Sprintf("%q (pid %d) exited (code %d): %s",
-			e.args,
-			ee.Pid(),
-			ee.ExitCode(),
-			ee.ProcessState.String())
-		if e.ctxErr != nil {
-			out += fmt.Sprintf("\n%s", e.ctxErr)
-		}
-	} else {
-		out = fmt.Sprintf("%q exited: %s", e.args, e.err.Error())
-		if e.ctxErr != nil && !errors.Is(e.err, e.ctxErr) {
-			out += fmt.Sprintf("\n%s", e.ctxErr)
-		}
-	}
-
-	if e.stderr != "" {
-		out += fmt.Sprintf("\nstderr: %q", e.stderr)
-	}
-
-	return out
 }

--- a/tfexec/errors_exiterror.go
+++ b/tfexec/errors_exiterror.go
@@ -1,0 +1,35 @@
+// +build !go1.12,!go1.13
+
+package tfexec
+
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+)
+
+func (e *ExitError) Error() string {
+	var out string
+	ee, ok := e.err.(*exec.ExitError)
+	if ok {
+		out = fmt.Sprintf("%q (pid %d) exited (code %d): %s",
+			e.args,
+			ee.Pid(),
+			ee.ExitCode(),
+			ee.ProcessState.String())
+		if e.ctxErr != nil {
+			out += fmt.Sprintf("\n%s", e.ctxErr)
+		}
+	} else {
+		out = fmt.Sprintf("%q exited: %s", e.args, e.err.Error())
+		if e.ctxErr != nil && !errors.Is(e.err, e.ctxErr) {
+			out += fmt.Sprintf("\n%s", e.ctxErr)
+		}
+	}
+
+	if e.stderr != "" {
+		out += fmt.Sprintf("\nstderr: %q", e.stderr)
+	}
+
+	return out
+}

--- a/tfexec/errors_exiterror_go112.go
+++ b/tfexec/errors_exiterror_go112.go
@@ -1,0 +1,34 @@
+// +build go1.12 go1.13
+
+package tfexec
+
+import (
+	"fmt"
+	"os/exec"
+)
+
+func (e *ExitError) Error() string {
+	var out string
+	ee, ok := e.err.(*exec.ExitError)
+	if ok {
+		out = fmt.Sprintf("%q (pid %d) exited (code %d): %s",
+			e.args,
+			ee.Pid(),
+			ee.ExitCode(),
+			ee.ProcessState.String())
+		if e.ctxErr != nil {
+			out += fmt.Sprintf("\n%s", e.ctxErr)
+		}
+	} else {
+		out = fmt.Sprintf("%q exited: %s", e.args, e.err.Error())
+		if e.ctxErr != nil {
+			out += fmt.Sprintf("\n%s", e.ctxErr)
+		}
+	}
+
+	if e.stderr != "" {
+		out += fmt.Sprintf("\nstderr: %q", e.stderr)
+	}
+
+	return out
+}

--- a/tfexec/errors_test.go
+++ b/tfexec/errors_test.go
@@ -3,7 +3,9 @@ package tfexec
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
+	"os/exec"
 	"testing"
 	"time"
 )
@@ -35,6 +37,49 @@ func TestContext_alreadyTimedOut(t *testing.T) {
 	if !isCtxErr {
 		t.Fatalf("expected error to be context.DeadlineExceeded compatible, given: %#v", err)
 	}
+}
+
+func TestContext_timeout(t *testing.T) {
+	ctx, cancelFunc := context.WithTimeout(context.Background(), 1*time.Millisecond)
+	t.Cleanup(cancelFunc)
+
+	td := testTempDir(t)
+	defer os.RemoveAll(td)
+
+	tf, err := NewTerraform(td, tfVersion(t, "0.13.1"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = tf.sleep(ctx, 1*time.Second)
+	if err == nil {
+		t.Fatal("expected error from timed out sleep")
+	}
+
+	ee := &ExitError{}
+	isExitErr := errors.As(err, &ee)
+	if !isExitErr {
+		t.Fatalf("expected error to be ExitError compatible, given: %#v", err)
+	}
+
+	isCtxErr := errors.Is(ee.ctxErr, context.DeadlineExceeded)
+	if !isCtxErr {
+		t.Fatalf("expected context error to be context.DeadlineExceeded")
+	}
+}
+
+func (tf *Terraform) sleep(ctx context.Context, d time.Duration) error {
+	seconds := fmt.Sprintf("%.0f", d.Seconds())
+	env := map[string]string{}
+	cmd := tf.buildTerraformCmd(ctx, env, seconds)
+
+	sPath, err := exec.LookPath("sleep")
+	if err != nil {
+		return err
+	}
+	cmd.Path = sPath
+	cmd.Args[0] = sPath
+
+	return tf.runTerraformCmd(ctx, cmd)
 }
 
 func TestContext_alreadyCancelled(t *testing.T) {

--- a/tfexec/errors_test.go
+++ b/tfexec/errors_test.go
@@ -1,0 +1,67 @@
+package tfexec
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestContext_alreadyTimedOut(t *testing.T) {
+	ctx, cancelFunc := context.WithTimeout(context.Background(), 1*time.Microsecond)
+	t.Cleanup(cancelFunc)
+
+	td := testTempDir(t)
+	defer os.RemoveAll(td)
+
+	tf, err := NewTerraform(td, tfVersion(t, "0.13.1"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _, err = tf.Version(ctx, true)
+	if err == nil {
+		t.Fatal("expected error from version command")
+	}
+
+	ee := &ExitError{}
+	isExitErr := errors.As(err, &ee)
+	if !isExitErr {
+		t.Fatalf("expected error to be ExitError compatible, given: %#v", err)
+	}
+
+	dee := context.DeadlineExceeded
+	isCtxErr := errors.Is(err, dee)
+	if !isCtxErr {
+		t.Fatalf("expected error to be context.DeadlineExceeded compatible, given: %#v", err)
+	}
+}
+
+func TestContext_alreadyCancelled(t *testing.T) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	cancelFunc()
+
+	td := testTempDir(t)
+	defer os.RemoveAll(td)
+
+	tf, err := NewTerraform(td, tfVersion(t, "0.13.1"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _, err = tf.Version(ctx, true)
+	if err == nil {
+		t.Fatal("expected error from version command")
+	}
+
+	ee := &ExitError{}
+	isExitErr := errors.As(err, &ee)
+	if !isExitErr {
+		t.Fatalf("expected error to be ExitError compatible, given: %#v", err)
+	}
+
+	dee := context.Canceled
+	isCtxErr := errors.Is(err, dee)
+	if !isCtxErr {
+		t.Fatalf("expected error to be context.Canceled compatible, given: %#v", err)
+	}
+}

--- a/tfexec/fmt.go
+++ b/tfexec/fmt.go
@@ -52,7 +52,7 @@ func (tf *Terraform) FormatString(ctx context.Context, content string) (string, 
 	var outBuf bytes.Buffer
 	cmd.Stdout = mergeWriters(cmd.Stdout, &outBuf)
 
-	err = tf.runTerraformCmd(cmd)
+	err = tf.runTerraformCmd(ctx, cmd)
 	if err != nil {
 		return "", err
 	}
@@ -76,7 +76,7 @@ func (tf *Terraform) FormatWrite(ctx context.Context, opts ...FormatOption) erro
 		return err
 	}
 
-	return tf.runTerraformCmd(cmd)
+	return tf.runTerraformCmd(ctx, cmd)
 }
 
 // FormatCheck returns true if the config files in the working or selected (via DirOption) directory are already formatted.
@@ -98,7 +98,7 @@ func (tf *Terraform) FormatCheck(ctx context.Context, opts ...FormatOption) (boo
 	var outBuf bytes.Buffer
 	cmd.Stdout = mergeWriters(cmd.Stdout, &outBuf)
 
-	err = tf.runTerraformCmd(cmd)
+	err = tf.runTerraformCmd(ctx, cmd)
 	if err == nil {
 		return true, nil, nil
 	}

--- a/tfexec/import.go
+++ b/tfexec/import.go
@@ -78,7 +78,7 @@ func (tf *Terraform) Import(ctx context.Context, address, id string, opts ...Imp
 	if err != nil {
 		return err
 	}
-	return tf.runTerraformCmd(cmd)
+	return tf.runTerraformCmd(ctx, cmd)
 }
 
 func (tf *Terraform) importCmd(ctx context.Context, address, id string, opts ...ImportOption) (*exec.Cmd, error) {

--- a/tfexec/init.go
+++ b/tfexec/init.go
@@ -98,7 +98,7 @@ func (tf *Terraform) Init(ctx context.Context, opts ...InitOption) error {
 	if err != nil {
 		return err
 	}
-	return tf.runTerraformCmd(cmd)
+	return tf.runTerraformCmd(ctx, cmd)
 }
 
 func (tf *Terraform) initCmd(ctx context.Context, opts ...InitOption) (*exec.Cmd, error) {

--- a/tfexec/output.go
+++ b/tfexec/output.go
@@ -37,7 +37,7 @@ func (tf *Terraform) Output(ctx context.Context, opts ...OutputOption) (map[stri
 	outputCmd := tf.outputCmd(ctx, opts...)
 
 	outputs := map[string]OutputMeta{}
-	err := tf.runTerraformCmdJSON(outputCmd, &outputs)
+	err := tf.runTerraformCmdJSON(ctx, outputCmd, &outputs)
 	if err != nil {
 		return nil, err
 	}

--- a/tfexec/plan.go
+++ b/tfexec/plan.go
@@ -96,7 +96,7 @@ func (tf *Terraform) Plan(ctx context.Context, opts ...PlanOption) (bool, error)
 	if err != nil {
 		return false, err
 	}
-	err = tf.runTerraformCmd(cmd)
+	err = tf.runTerraformCmd(ctx, cmd)
 	if err != nil && cmd.ProcessState.ExitCode() == 2 {
 		return true, nil
 	}

--- a/tfexec/providers_schema.go
+++ b/tfexec/providers_schema.go
@@ -12,7 +12,7 @@ func (tf *Terraform) ProvidersSchema(ctx context.Context) (*tfjson.ProviderSchem
 	schemaCmd := tf.providersSchemaCmd(ctx)
 
 	var ret tfjson.ProviderSchemas
-	err := tf.runTerraformCmdJSON(schemaCmd, &ret)
+	err := tf.runTerraformCmdJSON(ctx, schemaCmd, &ret)
 	if err != nil {
 		return nil, err
 	}

--- a/tfexec/refresh.go
+++ b/tfexec/refresh.go
@@ -75,7 +75,7 @@ func (tf *Terraform) Refresh(ctx context.Context, opts ...RefreshCmdOption) erro
 	if err != nil {
 		return err
 	}
-	return tf.runTerraformCmd(cmd)
+	return tf.runTerraformCmd(ctx, cmd)
 }
 
 func (tf *Terraform) refreshCmd(ctx context.Context, opts ...RefreshCmdOption) (*exec.Cmd, error) {

--- a/tfexec/show.go
+++ b/tfexec/show.go
@@ -49,7 +49,7 @@ func (tf *Terraform) Show(ctx context.Context, opts ...ShowOption) (*tfjson.Stat
 	showCmd := tf.showCmd(ctx, true, mergeEnv)
 
 	var ret tfjson.State
-	err = tf.runTerraformCmdJSON(showCmd, &ret)
+	err = tf.runTerraformCmdJSON(ctx, showCmd, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -91,7 +91,7 @@ func (tf *Terraform) ShowStateFile(ctx context.Context, statePath string, opts .
 	showCmd := tf.showCmd(ctx, true, mergeEnv, statePath)
 
 	var ret tfjson.State
-	err = tf.runTerraformCmdJSON(showCmd, &ret)
+	err = tf.runTerraformCmdJSON(ctx, showCmd, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -133,7 +133,7 @@ func (tf *Terraform) ShowPlanFile(ctx context.Context, planPath string, opts ...
 	showCmd := tf.showCmd(ctx, true, mergeEnv, planPath)
 
 	var ret tfjson.Plan
-	err = tf.runTerraformCmdJSON(showCmd, &ret)
+	err = tf.runTerraformCmdJSON(ctx, showCmd, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -173,7 +173,7 @@ func (tf *Terraform) ShowPlanFileRaw(ctx context.Context, planPath string, opts 
 
 	var ret bytes.Buffer
 	showCmd.Stdout = &ret
-	err := tf.runTerraformCmd(showCmd)
+	err := tf.runTerraformCmd(ctx, showCmd)
 	if err != nil {
 		return "", err
 	}

--- a/tfexec/version.go
+++ b/tfexec/version.go
@@ -44,7 +44,7 @@ func (tf *Terraform) version(ctx context.Context) (*version.Version, map[string]
 	var outBuf bytes.Buffer
 	versionCmd.Stdout = &outBuf
 
-	err := tf.runTerraformCmd(versionCmd)
+	err := tf.runTerraformCmd(ctx, versionCmd)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/tfexec/workspace_list.go
+++ b/tfexec/workspace_list.go
@@ -14,7 +14,7 @@ func (tf *Terraform) WorkspaceList(ctx context.Context) ([]string, string, error
 	var outBuf bytes.Buffer
 	wlCmd.Stdout = &outBuf
 
-	err := tf.runTerraformCmd(wlCmd)
+	err := tf.runTerraformCmd(ctx, wlCmd)
 	if err != nil {
 		return nil, "", err
 	}

--- a/tfexec/workspace_new.go
+++ b/tfexec/workspace_new.go
@@ -41,7 +41,7 @@ func (tf *Terraform) WorkspaceNew(ctx context.Context, workspace string, opts ..
 	if err != nil {
 		return err
 	}
-	return tf.runTerraformCmd(cmd)
+	return tf.runTerraformCmd(ctx, cmd)
 }
 
 func (tf *Terraform) workspaceNewCmd(ctx context.Context, workspace string, opts ...WorkspaceNewCmdOption) (*exec.Cmd, error) {

--- a/tfexec/workspace_select.go
+++ b/tfexec/workspace_select.go
@@ -6,5 +6,5 @@ import "context"
 func (tf *Terraform) WorkspaceSelect(ctx context.Context, workspace string) error {
 	// TODO: [DIR] param option
 
-	return tf.runTerraformCmd(tf.buildTerraformCmd(ctx, nil, "workspace", "select", "-no-color", workspace))
+	return tf.runTerraformCmd(ctx, tf.buildTerraformCmd(ctx, nil, "workspace", "select", "-no-color", workspace))
 }


### PR DESCRIPTION
Previously the following `context.*` errors would be returned when the Terraform execution can't start because the context passed was already cancelled.

```
context deadline exceeded
```
```
context canceled
```

This is being replaced with more informative custom `ExitError`, e.g.

```
["/path/to/0.13.1/terraform" "version"] exited: context deadline exceeded
```

--- 

The following `exec.ExitError` error would be returned when execution is interrupted due to context (cancellation or deadline):

```
signal: killed
```

which is being replaced with `ExitError` too

```
["sleep" "1"] (pid 71492) exited (code -1): signal: killed
context deadline exceeded
```

--- 

Importantly the `ExitError` implements `Unwrap` to remain comparable with the original context errors or `exec.ExitError`, as demonstrated in attached tests.

--- 

We can make deadline errors even more informative by making timeout a first-class concept and implementing custom `context.Context` which reflects that. Once that is done, the error handling here should in theory just pick it up - only tests may need to be updated. I'll raise a separate PR for this though.