### PR TITLE
Better support for errors.Is and errors.As

### DIFF
--- a/tfexec/apply.go
+++ b/tfexec/apply.go
@@ -91,7 +91,7 @@ func (tf *Terraform) Apply(ctx context.Context, opts ...ApplyOption) error {
 	if err != nil {
 		return err
 	}
-	return tf.runTerraformCmd(cmd)
+	return tf.runTerraformCmd(ctx, cmd)
 }
 
 func (tf *Terraform) applyCmd(ctx context.Context, opts ...ApplyOption) (*exec.Cmd, error) {

--- a/tfexec/cmd_default.go
+++ b/tfexec/cmd_default.go
@@ -1,0 +1,45 @@
+// +build !linux
+
+package tfexec
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+)
+
+func (tf *Terraform) runTerraformCmd(ctx context.Context, cmd *exec.Cmd) error {
+	var errBuf strings.Builder
+
+	cmd.Stdout = mergeWriters(cmd.Stdout, tf.stdout)
+	cmd.Stderr = mergeWriters(cmd.Stderr, tf.stderr, &errBuf)
+
+	go func() {
+		<-ctx.Done()
+		if ctx.Err() == context.DeadlineExceeded || ctx.Err() == context.Canceled {
+			if cmd != nil && cmd.Process != nil && cmd.ProcessState != nil {
+				err := cmd.Process.Kill()
+				if err != nil {
+					tf.logger.Printf("error from kill: %s", err)
+				}
+			}
+		}
+	}()
+
+	// check for early cancellation
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
+	err := cmd.Run()
+	if err == nil && ctx.Err() != nil {
+		err = ctx.Err()
+	}
+	if err != nil {
+		return tf.parseError(err, errBuf.String())
+	}
+
+	return nil
+}

--- a/tfexec/cmd_default.go
+++ b/tfexec/cmd_default.go
@@ -38,7 +38,7 @@ func (tf *Terraform) runTerraformCmd(ctx context.Context, cmd *exec.Cmd) error {
 		err = ctx.Err()
 	}
 	if err != nil {
-		return tf.parseError(err, errBuf.String())
+		return tf.wrapExitError(ctx, err, errBuf.String())
 	}
 
 	return nil

--- a/tfexec/cmd_linux.go
+++ b/tfexec/cmd_linux.go
@@ -1,0 +1,54 @@
+package tfexec
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"syscall"
+)
+
+func (tf *Terraform) runTerraformCmd(ctx context.Context, cmd *exec.Cmd) error {
+	var errBuf strings.Builder
+
+	cmd.Stdout = mergeWriters(cmd.Stdout, tf.stdout)
+	cmd.Stderr = mergeWriters(cmd.Stderr, tf.stderr, &errBuf)
+
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		// kill children if parent is dead
+		Pdeathsig: syscall.SIGKILL,
+		// set process group ID
+		Setpgid: true,
+	}
+
+	go func() {
+		<-ctx.Done()
+		if ctx.Err() == context.DeadlineExceeded || ctx.Err() == context.Canceled {
+			if cmd != nil && cmd.Process != nil && cmd.ProcessState != nil {
+				// send SIGINT to process group
+				err := syscall.Kill(-cmd.Process.Pid, syscall.SIGINT)
+				if err != nil {
+					tf.logger.Printf("error from SIGINT: %s", err)
+				}
+			}
+
+			// TODO: send a kill if it doesn't respond for a bit?
+		}
+	}()
+
+	// check for early cancellation
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
+	err := cmd.Run()
+	if err == nil && ctx.Err() != nil {
+		err = ctx.Err()
+	}
+	if err != nil {
+		return tf.parseError(err, errBuf.String())
+	}
+
+	return nil
+}

--- a/tfexec/cmd_linux.go
+++ b/tfexec/cmd_linux.go
@@ -47,7 +47,7 @@ func (tf *Terraform) runTerraformCmd(ctx context.Context, cmd *exec.Cmd) error {
 		err = ctx.Err()
 	}
 	if err != nil {
-		return tf.parseError(err, errBuf.String())
+		return tf.wrapExitError(ctx, err, errBuf.String())
 	}
 
 	return nil

--- a/tfexec/destroy.go
+++ b/tfexec/destroy.go
@@ -92,7 +92,7 @@ func (tf *Terraform) Destroy(ctx context.Context, opts ...DestroyOption) error {
 	if err != nil {
 		return err
 	}
-	return tf.runTerraformCmd(cmd)
+	return tf.runTerraformCmd(ctx, cmd)
 }
 
 func (tf *Terraform) destroyCmd(ctx context.Context, opts ...DestroyOption) (*exec.Cmd, error) {

--- a/tfexec/errors.go
+++ b/tfexec/errors.go
@@ -1,111 +1,8 @@
 package tfexec
 
-import (
-	"errors"
-	"fmt"
-	"os/exec"
-	"regexp"
-	"strings"
-)
+import "fmt"
 
-var (
-	// The "Required variable not set:" case is for 0.11
-	missingVarErrRegexp  = regexp.MustCompile(`Error: No value for required variable|Error: Required variable not set:`)
-	missingVarNameRegexp = regexp.MustCompile(`The root module input variable\s"(.+)"\sis\snot\sset,\sand\shas\sno\sdefault|Error: Required variable not set: (.+)`)
-
-	usageRegexp = regexp.MustCompile(`Too many command line arguments|^Usage: .*Options:.*|Error: Invalid -\d+ option`)
-
-	// "Could not load plugin" is present in 0.13
-	noInitErrRegexp = regexp.MustCompile(`Error: Could not satisfy plugin requirements|Error: Could not load plugin`)
-
-	noConfigErrRegexp = regexp.MustCompile(`Error: No configuration files`)
-
-	workspaceDoesNotExistRegexp = regexp.MustCompile(`Workspace "(.+)" doesn't exist.`)
-
-	workspaceAlreadyExistsRegexp = regexp.MustCompile(`Workspace "(.+)" already exists`)
-
-	tfVersionMismatchErrRegexp        = regexp.MustCompile(`Error: The currently running version of Terraform doesn't meet the|Error: Unsupported Terraform Core version`)
-	tfVersionMismatchConstraintRegexp = regexp.MustCompile(`required_version = "(.+)"|Required version: (.+)\b`)
-	configInvalidErrRegexp            = regexp.MustCompile(`There are some problems with the configuration, described below.`)
-)
-
-func (tf *Terraform) parseError(err error, stderr string) error {
-	ee, ok := err.(*exec.ExitError)
-	if !ok {
-		return err
-	}
-
-	switch {
-	case tfVersionMismatchErrRegexp.MatchString(stderr):
-		constraint := ""
-		constraints := tfVersionMismatchConstraintRegexp.FindStringSubmatch(stderr)
-		for i := 1; i < len(constraints); i++ {
-			constraint = strings.TrimSpace(constraints[i])
-			if constraint != "" {
-				break
-			}
-		}
-
-		if constraint == "" {
-			// hardcode a value here for weird cases (incl. 0.12)
-			constraint = "unknown"
-		}
-
-		// only set this if it happened to be cached already
-		ver := ""
-		if tf != nil && tf.execVersion != nil {
-			ver = tf.execVersion.String()
-		}
-
-		return &ErrTFVersionMismatch{
-			Constraint: constraint,
-			TFVersion:  ver,
-		}
-	case missingVarErrRegexp.MatchString(stderr):
-		name := ""
-		names := missingVarNameRegexp.FindStringSubmatch(stderr)
-		for i := 1; i < len(names); i++ {
-			name = strings.TrimSpace(names[i])
-			if name != "" {
-				break
-			}
-		}
-
-		return &ErrMissingVar{name}
-	case usageRegexp.MatchString(stderr):
-		return &ErrCLIUsage{stderr: stderr}
-	case noInitErrRegexp.MatchString(stderr):
-		return &ErrNoInit{stderr: stderr}
-	case noConfigErrRegexp.MatchString(stderr):
-		return &ErrNoConfig{stderr: stderr}
-	case workspaceDoesNotExistRegexp.MatchString(stderr):
-		submatches := workspaceDoesNotExistRegexp.FindStringSubmatch(stderr)
-		if len(submatches) == 2 {
-			return &ErrNoWorkspace{submatches[1]}
-		}
-	case workspaceAlreadyExistsRegexp.MatchString(stderr):
-		submatches := workspaceAlreadyExistsRegexp.FindStringSubmatch(stderr)
-		if len(submatches) == 2 {
-			return &ErrWorkspaceExists{submatches[1]}
-		}
-	case configInvalidErrRegexp.MatchString(stderr):
-		return &ErrConfigInvalid{stderr: stderr}
-	}
-	errString := strings.TrimSpace(stderr)
-	if errString == "" {
-		// if stderr is empty, return the ExitError directly, as it will have a better message
-		return ee
-	}
-	return errors.New(stderr)
-}
-
-type ErrConfigInvalid struct {
-	stderr string
-}
-
-func (e *ErrConfigInvalid) Error() string {
-	return "configuration is invalid"
-}
+// this file contains non-parsed exported errors
 
 type ErrNoSuitableBinary struct {
 	err error
@@ -113,19 +10,6 @@ type ErrNoSuitableBinary struct {
 
 func (e *ErrNoSuitableBinary) Error() string {
 	return fmt.Sprintf("no suitable terraform binary could be found: %s", e.err.Error())
-}
-
-// ErrTFVersionMismatch is returned when the running Terraform version is not compatible with the
-// value specified for required_version in the terraform block.
-type ErrTFVersionMismatch struct {
-	TFVersion string
-
-	// Constraint is not returned in the error messaging on 0.12
-	Constraint string
-}
-
-func (e *ErrTFVersionMismatch) Error() string {
-	return "terraform core version not supported by configuration"
 }
 
 // ErrVersionMismatch is returned when the detected Terraform version is not compatible with the
@@ -140,38 +24,6 @@ func (e *ErrVersionMismatch) Error() string {
 	return fmt.Sprintf("unexpected version %s (min: %s, max: %s)", e.Actual, e.MinInclusive, e.MaxExclusive)
 }
 
-type ErrNoInit struct {
-	stderr string
-}
-
-func (e *ErrNoInit) Error() string {
-	return e.stderr
-}
-
-type ErrNoConfig struct {
-	stderr string
-}
-
-func (e *ErrNoConfig) Error() string {
-	return e.stderr
-}
-
-// ErrCLIUsage is returned when the combination of flags or arguments is incorrect.
-//
-//  CLI indicates usage errors in three different ways: either
-// 1. Exit 1, with a custom error message on stderr.
-// 2. Exit 1, with command usage logged to stderr.
-// 3. Exit 127, with command usage logged to stdout.
-// Currently cases 1 and 2 are handled.
-// TODO KEM: Handle exit 127 case. How does this work on non-Unix platforms?
-type ErrCLIUsage struct {
-	stderr string
-}
-
-func (e *ErrCLIUsage) Error() string {
-	return e.stderr
-}
-
 // ErrManualEnvVar is returned when an env var that should be set programatically via an option or method
 // is set via the manual environment passing functions.
 type ErrManualEnvVar struct {
@@ -180,29 +32,4 @@ type ErrManualEnvVar struct {
 
 func (err *ErrManualEnvVar) Error() string {
 	return fmt.Sprintf("manual setting of env var %q detected", err.name)
-}
-
-type ErrMissingVar struct {
-	VariableName string
-}
-
-func (err *ErrMissingVar) Error() string {
-	return fmt.Sprintf("variable %q was required but not supplied", err.VariableName)
-}
-
-type ErrNoWorkspace struct {
-	Name string
-}
-
-func (err *ErrNoWorkspace) Error() string {
-	return fmt.Sprintf("workspace %q does not exist", err.Name)
-}
-
-// ErrWorkspaceExists is returned when creating a workspace that already exists
-type ErrWorkspaceExists struct {
-	Name string
-}
-
-func (err *ErrWorkspaceExists) Error() string {
-	return fmt.Sprintf("workspace %q already exists", err.Name)
 }

--- a/tfexec/errors.go
+++ b/tfexec/errors.go
@@ -12,6 +12,10 @@ func (e *ErrNoSuitableBinary) Error() string {
 	return fmt.Sprintf("no suitable terraform binary could be found: %s", e.err.Error())
 }
 
+func (e *ErrNoSuitableBinary) Unwrap() error {
+	return e.err
+}
+
 // ErrVersionMismatch is returned when the detected Terraform version is not compatible with the
 // command or flags being used in this invocation.
 type ErrVersionMismatch struct {
@@ -27,9 +31,9 @@ func (e *ErrVersionMismatch) Error() string {
 // ErrManualEnvVar is returned when an env var that should be set programatically via an option or method
 // is set via the manual environment passing functions.
 type ErrManualEnvVar struct {
-	name string
+	Name string
 }
 
 func (err *ErrManualEnvVar) Error() string {
-	return fmt.Sprintf("manual setting of env var %q detected", err.name)
+	return fmt.Sprintf("manual setting of env var %q detected", err.Name)
 }

--- a/tfexec/exit_errors.go
+++ b/tfexec/exit_errors.go
@@ -1,7 +1,7 @@
 package tfexec
 
 import (
-	"errors"
+	"context"
 	"fmt"
 	"os/exec"
 	"regexp"
@@ -31,10 +31,19 @@ var (
 	configInvalidErrRegexp            = regexp.MustCompile(`There are some problems with the configuration, described below.`)
 )
 
-func (tf *Terraform) parseError(err error, stderr string) error {
-	ee, ok := err.(*exec.ExitError)
+func (tf *Terraform) wrapExitError(ctx context.Context, err error, stderr string) error {
+	exitErr, ok := err.(*exec.ExitError)
 	if !ok {
+		// not an exit error, short circuit, nothing to wrap
 		return err
+	}
+
+	ctxErr := ctx.Err()
+
+	// nothing to parse, return early
+	errString := strings.TrimSpace(stderr)
+	if errString == "" {
+		return &unwrapper{exitErr, ctxErr}
 	}
 
 	switch {
@@ -60,6 +69,8 @@ func (tf *Terraform) parseError(err error, stderr string) error {
 		}
 
 		return &ErrTFVersionMismatch{
+			unwrapper: unwrapper{exitErr, ctxErr},
+
 			Constraint: constraint,
 			TFVersion:  ver,
 		}
@@ -73,32 +84,74 @@ func (tf *Terraform) parseError(err error, stderr string) error {
 			}
 		}
 
-		return &ErrMissingVar{name}
+		return &ErrMissingVar{
+			unwrapper: unwrapper{exitErr, ctxErr},
+
+			VariableName: name,
+		}
 	case usageRegexp.MatchString(stderr):
-		return &ErrCLIUsage{stderr: stderr}
+		return &ErrCLIUsage{
+			unwrapper: unwrapper{exitErr, ctxErr},
+
+			stderr: stderr,
+		}
 	case noInitErrRegexp.MatchString(stderr):
-		return &ErrNoInit{stderr: stderr}
+		return &ErrNoInit{
+			unwrapper: unwrapper{exitErr, ctxErr},
+
+			stderr: stderr,
+		}
 	case noConfigErrRegexp.MatchString(stderr):
-		return &ErrNoConfig{stderr: stderr}
+		return &ErrNoConfig{
+			unwrapper: unwrapper{exitErr, ctxErr},
+
+			stderr: stderr,
+		}
 	case workspaceDoesNotExistRegexp.MatchString(stderr):
 		submatches := workspaceDoesNotExistRegexp.FindStringSubmatch(stderr)
 		if len(submatches) == 2 {
-			return &ErrNoWorkspace{submatches[1]}
+			return &ErrNoWorkspace{
+				unwrapper: unwrapper{exitErr, ctxErr},
+
+				Name: submatches[1],
+			}
 		}
 	case workspaceAlreadyExistsRegexp.MatchString(stderr):
 		submatches := workspaceAlreadyExistsRegexp.FindStringSubmatch(stderr)
 		if len(submatches) == 2 {
-			return &ErrWorkspaceExists{submatches[1]}
+			return &ErrWorkspaceExists{
+				unwrapper: unwrapper{exitErr, ctxErr},
+
+				Name: submatches[1],
+			}
 		}
 	case configInvalidErrRegexp.MatchString(stderr):
 		return &ErrConfigInvalid{stderr: stderr}
 	}
-	errString := strings.TrimSpace(stderr)
-	if errString == "" {
-		// if stderr is empty, return the ExitError directly, as it will have a better message
-		return ee
+
+	return fmt.Errorf("%w\n%s", &unwrapper{exitErr, ctxErr}, stderr)
+}
+
+type unwrapper struct {
+	err    error
+	ctxErr error
+}
+
+func (u *unwrapper) Unwrap() error {
+	return u.err
+}
+
+func (u *unwrapper) Is(target error) bool {
+	switch target {
+	case context.DeadlineExceeded, context.Canceled:
+		return u.ctxErr == context.DeadlineExceeded ||
+			u.ctxErr == context.Canceled
 	}
-	return errors.New(stderr)
+	return false
+}
+
+func (u *unwrapper) Error() string {
+	return u.err.Error()
 }
 
 type ErrConfigInvalid struct {
@@ -110,6 +163,8 @@ func (e *ErrConfigInvalid) Error() string {
 }
 
 type ErrMissingVar struct {
+	unwrapper
+
 	VariableName string
 }
 
@@ -118,6 +173,8 @@ func (err *ErrMissingVar) Error() string {
 }
 
 type ErrNoWorkspace struct {
+	unwrapper
+
 	Name string
 }
 
@@ -127,6 +184,8 @@ func (err *ErrNoWorkspace) Error() string {
 
 // ErrWorkspaceExists is returned when creating a workspace that already exists
 type ErrWorkspaceExists struct {
+	unwrapper
+
 	Name string
 }
 
@@ -135,6 +194,8 @@ func (err *ErrWorkspaceExists) Error() string {
 }
 
 type ErrNoInit struct {
+	unwrapper
+
 	stderr string
 }
 
@@ -143,6 +204,8 @@ func (e *ErrNoInit) Error() string {
 }
 
 type ErrNoConfig struct {
+	unwrapper
+
 	stderr string
 }
 
@@ -159,6 +222,8 @@ func (e *ErrNoConfig) Error() string {
 // Currently cases 1 and 2 are handled.
 // TODO KEM: Handle exit 127 case. How does this work on non-Unix platforms?
 type ErrCLIUsage struct {
+	unwrapper
+
 	stderr string
 }
 
@@ -169,6 +234,8 @@ func (e *ErrCLIUsage) Error() string {
 // ErrTFVersionMismatch is returned when the running Terraform version is not compatible with the
 // value specified for required_version in the terraform block.
 type ErrTFVersionMismatch struct {
+	unwrapper
+
 	TFVersion string
 
 	// Constraint is not returned in the error messaging on 0.12

--- a/tfexec/exit_errors.go
+++ b/tfexec/exit_errors.go
@@ -1,0 +1,180 @@
+package tfexec
+
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strings"
+)
+
+// this file contains errors parsed from stderr
+
+var (
+	// The "Required variable not set:" case is for 0.11
+	missingVarErrRegexp  = regexp.MustCompile(`Error: No value for required variable|Error: Required variable not set:`)
+	missingVarNameRegexp = regexp.MustCompile(`The root module input variable\s"(.+)"\sis\snot\sset,\sand\shas\sno\sdefault|Error: Required variable not set: (.+)`)
+
+	usageRegexp = regexp.MustCompile(`Too many command line arguments|^Usage: .*Options:.*|Error: Invalid -\d+ option`)
+
+	// "Could not load plugin" is present in 0.13
+	noInitErrRegexp = regexp.MustCompile(`Error: Could not satisfy plugin requirements|Error: Could not load plugin`)
+
+	noConfigErrRegexp = regexp.MustCompile(`Error: No configuration files`)
+
+	workspaceDoesNotExistRegexp = regexp.MustCompile(`Workspace "(.+)" doesn't exist.`)
+
+	workspaceAlreadyExistsRegexp = regexp.MustCompile(`Workspace "(.+)" already exists`)
+
+	tfVersionMismatchErrRegexp        = regexp.MustCompile(`Error: The currently running version of Terraform doesn't meet the|Error: Unsupported Terraform Core version`)
+	tfVersionMismatchConstraintRegexp = regexp.MustCompile(`required_version = "(.+)"|Required version: (.+)\b`)
+	configInvalidErrRegexp            = regexp.MustCompile(`There are some problems with the configuration, described below.`)
+)
+
+func (tf *Terraform) parseError(err error, stderr string) error {
+	ee, ok := err.(*exec.ExitError)
+	if !ok {
+		return err
+	}
+
+	switch {
+	case tfVersionMismatchErrRegexp.MatchString(stderr):
+		constraint := ""
+		constraints := tfVersionMismatchConstraintRegexp.FindStringSubmatch(stderr)
+		for i := 1; i < len(constraints); i++ {
+			constraint = strings.TrimSpace(constraints[i])
+			if constraint != "" {
+				break
+			}
+		}
+
+		if constraint == "" {
+			// hardcode a value here for weird cases (incl. 0.12)
+			constraint = "unknown"
+		}
+
+		// only set this if it happened to be cached already
+		ver := ""
+		if tf != nil && tf.execVersion != nil {
+			ver = tf.execVersion.String()
+		}
+
+		return &ErrTFVersionMismatch{
+			Constraint: constraint,
+			TFVersion:  ver,
+		}
+	case missingVarErrRegexp.MatchString(stderr):
+		name := ""
+		names := missingVarNameRegexp.FindStringSubmatch(stderr)
+		for i := 1; i < len(names); i++ {
+			name = strings.TrimSpace(names[i])
+			if name != "" {
+				break
+			}
+		}
+
+		return &ErrMissingVar{name}
+	case usageRegexp.MatchString(stderr):
+		return &ErrCLIUsage{stderr: stderr}
+	case noInitErrRegexp.MatchString(stderr):
+		return &ErrNoInit{stderr: stderr}
+	case noConfigErrRegexp.MatchString(stderr):
+		return &ErrNoConfig{stderr: stderr}
+	case workspaceDoesNotExistRegexp.MatchString(stderr):
+		submatches := workspaceDoesNotExistRegexp.FindStringSubmatch(stderr)
+		if len(submatches) == 2 {
+			return &ErrNoWorkspace{submatches[1]}
+		}
+	case workspaceAlreadyExistsRegexp.MatchString(stderr):
+		submatches := workspaceAlreadyExistsRegexp.FindStringSubmatch(stderr)
+		if len(submatches) == 2 {
+			return &ErrWorkspaceExists{submatches[1]}
+		}
+	case configInvalidErrRegexp.MatchString(stderr):
+		return &ErrConfigInvalid{stderr: stderr}
+	}
+	errString := strings.TrimSpace(stderr)
+	if errString == "" {
+		// if stderr is empty, return the ExitError directly, as it will have a better message
+		return ee
+	}
+	return errors.New(stderr)
+}
+
+type ErrConfigInvalid struct {
+	stderr string
+}
+
+func (e *ErrConfigInvalid) Error() string {
+	return "configuration is invalid"
+}
+
+type ErrMissingVar struct {
+	VariableName string
+}
+
+func (err *ErrMissingVar) Error() string {
+	return fmt.Sprintf("variable %q was required but not supplied", err.VariableName)
+}
+
+type ErrNoWorkspace struct {
+	Name string
+}
+
+func (err *ErrNoWorkspace) Error() string {
+	return fmt.Sprintf("workspace %q does not exist", err.Name)
+}
+
+// ErrWorkspaceExists is returned when creating a workspace that already exists
+type ErrWorkspaceExists struct {
+	Name string
+}
+
+func (err *ErrWorkspaceExists) Error() string {
+	return fmt.Sprintf("workspace %q already exists", err.Name)
+}
+
+type ErrNoInit struct {
+	stderr string
+}
+
+func (e *ErrNoInit) Error() string {
+	return e.stderr
+}
+
+type ErrNoConfig struct {
+	stderr string
+}
+
+func (e *ErrNoConfig) Error() string {
+	return e.stderr
+}
+
+// ErrCLIUsage is returned when the combination of flags or arguments is incorrect.
+//
+//  CLI indicates usage errors in three different ways: either
+// 1. Exit 1, with a custom error message on stderr.
+// 2. Exit 1, with command usage logged to stderr.
+// 3. Exit 127, with command usage logged to stdout.
+// Currently cases 1 and 2 are handled.
+// TODO KEM: Handle exit 127 case. How does this work on non-Unix platforms?
+type ErrCLIUsage struct {
+	stderr string
+}
+
+func (e *ErrCLIUsage) Error() string {
+	return e.stderr
+}
+
+// ErrTFVersionMismatch is returned when the running Terraform version is not compatible with the
+// value specified for required_version in the terraform block.
+type ErrTFVersionMismatch struct {
+	TFVersion string
+
+	// Constraint is not returned in the error messaging on 0.12
+	Constraint string
+}
+
+func (e *ErrTFVersionMismatch) Error() string {
+	return "terraform core version not supported by configuration"
+}

--- a/tfexec/fmt.go
+++ b/tfexec/fmt.go
@@ -63,7 +63,7 @@ func (tf *Terraform) Format(ctx context.Context, unformatted io.Reader, formatte
 	cmd.Stdin = unformatted
 	cmd.Stdout = mergeWriters(cmd.Stdout, formatted)
 
-	return tf.runTerraformCmd(cmd)
+	return tf.runTerraformCmd(ctx, cmd)
 }
 
 // FormatWrite attempts to format and modify all config files in the working or selected (via DirOption) directory.
@@ -82,7 +82,7 @@ func (tf *Terraform) FormatWrite(ctx context.Context, opts ...FormatOption) erro
 		return err
 	}
 
-	return tf.runTerraformCmd(cmd)
+	return tf.runTerraformCmd(ctx, cmd)
 }
 
 // FormatCheck returns true if the config files in the working or selected (via DirOption) directory are already formatted.
@@ -104,7 +104,7 @@ func (tf *Terraform) FormatCheck(ctx context.Context, opts ...FormatOption) (boo
 	var outBuf bytes.Buffer
 	cmd.Stdout = mergeWriters(cmd.Stdout, &outBuf)
 
-	err = tf.runTerraformCmd(cmd)
+	err = tf.runTerraformCmd(ctx, cmd)
 	if err == nil {
 		return true, nil, nil
 	}

--- a/tfexec/import.go
+++ b/tfexec/import.go
@@ -78,7 +78,7 @@ func (tf *Terraform) Import(ctx context.Context, address, id string, opts ...Imp
 	if err != nil {
 		return err
 	}
-	return tf.runTerraformCmd(cmd)
+	return tf.runTerraformCmd(ctx, cmd)
 }
 
 func (tf *Terraform) importCmd(ctx context.Context, address, id string, opts ...ImportOption) (*exec.Cmd, error) {

--- a/tfexec/init.go
+++ b/tfexec/init.go
@@ -98,7 +98,7 @@ func (tf *Terraform) Init(ctx context.Context, opts ...InitOption) error {
 	if err != nil {
 		return err
 	}
-	return tf.runTerraformCmd(cmd)
+	return tf.runTerraformCmd(ctx, cmd)
 }
 
 func (tf *Terraform) initCmd(ctx context.Context, opts ...InitOption) (*exec.Cmd, error) {

--- a/tfexec/internal/e2etest/errors_test.go
+++ b/tfexec/internal/e2etest/errors_test.go
@@ -7,11 +7,17 @@ import (
 	"context"
 	"errors"
 	"os"
+	"os/exec"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/go-version"
 
 	"github.com/hashicorp/terraform-exec/tfexec"
+)
+
+var (
+	protocol5MinVersion = version.Must(version.NewVersion("0.12.0"))
 )
 
 func TestUnparsedError(t *testing.T) {
@@ -74,6 +80,11 @@ func TestMissingVar(t *testing.T) {
 			t.Fatalf("expected missing %s, got %q", longVarName, e.VariableName)
 		}
 
+		var ee *exec.ExitError
+		if !errors.As(err, &ee) {
+			t.Fatalf("expected exec.ExitError, got %T, %s", err, err)
+		}
+
 		// Test for no error when all variables have a value
 		_, err = tf.Plan(context.Background(), tfexec.Var(shortVarName+"=foo"), tfexec.Var(longVarName+"=foo"))
 		if err != nil {
@@ -107,6 +118,96 @@ func TestTFVersionMismatch(t *testing.T) {
 
 		if e.TFVersion != tfv.String() {
 			t.Fatalf("expected %q, got %q", tfv.String(), e.TFVersion)
+		}
+
+		var ee *exec.ExitError
+		if !errors.As(err, &ee) {
+			t.Fatalf("expected exec.ExitError, got %T, %s", err, err)
+		}
+	})
+}
+
+func TestContext_alreadyPastDeadline(t *testing.T) {
+	runTest(t, "", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-1*time.Second))
+		defer cancel()
+
+		_, _, err := tf.Version(ctx, true)
+		if err == nil {
+			t.Fatal("expected error from version command")
+		}
+
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("expected context.DeadlineExceeded, got %T %s", err, err)
+		}
+	})
+}
+
+func TestContext_sleepNoCancellation(t *testing.T) {
+	// this test is just to ensure that time_sleep works properly without cancellation
+	runTest(t, "sleep", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+		// only testing versions that can cancel mid apply
+		if !tfv.GreaterThanOrEqual(protocol5MinVersion) {
+			t.Skip("the ability to interrupt an apply was added in protocol 5.0 in Terraform 0.12, so test is not valid")
+		}
+
+		err := tf.Init(context.Background())
+		if err != nil {
+			t.Fatalf("err during init: %s", err)
+		}
+
+		ctx := context.Background()
+		start := time.Now()
+		err = tf.Apply(ctx, tfexec.Var(`create_duration=5s`))
+		if err != nil {
+			t.Fatalf("error during apply: %s", err)
+		}
+		elapsed := time.Now().Sub(start)
+		if elapsed < 5*time.Second {
+			t.Fatalf("expected runtime of at least 5s, got %s", elapsed)
+		}
+	})
+}
+
+func TestContext_sleepTimeoutExpired(t *testing.T) {
+	runTest(t, "sleep", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+		// only testing versions that can cancel mid apply
+		if !tfv.GreaterThanOrEqual(protocol5MinVersion) {
+			t.Skip("the ability to interrupt an apply was added in protocol 5.0 in Terraform 0.12, so test is not valid")
+		}
+
+		err := tf.Init(context.Background())
+		if err != nil {
+			t.Fatalf("err during init: %s", err)
+		}
+
+		ctx := context.Background()
+		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+
+		err = tf.Apply(ctx)
+		if err == nil {
+			t.Fatal("expected error, but didn't find one")
+		}
+
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("expected context.DeadlineExceeded, got %T %s", err, err)
+		}
+	})
+}
+
+func TestContext_alreadyCancelled(t *testing.T) {
+	runTest(t, "", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		_, _, err := tf.Version(ctx, true)
+		if err == nil {
+			t.Fatal("expected error from version command")
+		}
+
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context.Canceled, got %T %s", err, err)
 		}
 	})
 }

--- a/tfexec/internal/e2etest/testdata/sleep/main.tf
+++ b/tfexec/internal/e2etest/testdata/sleep/main.tf
@@ -1,0 +1,14 @@
+variable "create_duration" {
+  type    = string
+  default = "60s"
+}
+
+variable "destroy_duration" {
+  type    = string
+  default = null
+}
+
+resource "time_sleep" "sleep" {
+  create_duration  = var.create_duration
+  destroy_duration = var.destroy_duration
+}

--- a/tfexec/output.go
+++ b/tfexec/output.go
@@ -37,7 +37,7 @@ func (tf *Terraform) Output(ctx context.Context, opts ...OutputOption) (map[stri
 	outputCmd := tf.outputCmd(ctx, opts...)
 
 	outputs := map[string]OutputMeta{}
-	err := tf.runTerraformCmdJSON(outputCmd, &outputs)
+	err := tf.runTerraformCmdJSON(ctx, outputCmd, &outputs)
 	if err != nil {
 		return nil, err
 	}

--- a/tfexec/plan.go
+++ b/tfexec/plan.go
@@ -96,7 +96,7 @@ func (tf *Terraform) Plan(ctx context.Context, opts ...PlanOption) (bool, error)
 	if err != nil {
 		return false, err
 	}
-	err = tf.runTerraformCmd(cmd)
+	err = tf.runTerraformCmd(ctx, cmd)
 	if err != nil && cmd.ProcessState.ExitCode() == 2 {
 		return true, nil
 	}

--- a/tfexec/providers_schema.go
+++ b/tfexec/providers_schema.go
@@ -12,7 +12,7 @@ func (tf *Terraform) ProvidersSchema(ctx context.Context) (*tfjson.ProviderSchem
 	schemaCmd := tf.providersSchemaCmd(ctx)
 
 	var ret tfjson.ProviderSchemas
-	err := tf.runTerraformCmdJSON(schemaCmd, &ret)
+	err := tf.runTerraformCmdJSON(ctx, schemaCmd, &ret)
 	if err != nil {
 		return nil, err
 	}

--- a/tfexec/refresh.go
+++ b/tfexec/refresh.go
@@ -75,7 +75,7 @@ func (tf *Terraform) Refresh(ctx context.Context, opts ...RefreshCmdOption) erro
 	if err != nil {
 		return err
 	}
-	return tf.runTerraformCmd(cmd)
+	return tf.runTerraformCmd(ctx, cmd)
 }
 
 func (tf *Terraform) refreshCmd(ctx context.Context, opts ...RefreshCmdOption) (*exec.Cmd, error) {

--- a/tfexec/show.go
+++ b/tfexec/show.go
@@ -50,7 +50,7 @@ func (tf *Terraform) Show(ctx context.Context, opts ...ShowOption) (*tfjson.Stat
 
 	var ret tfjson.State
 	ret.UseJSONNumber(true)
-	err = tf.runTerraformCmdJSON(showCmd, &ret)
+	err = tf.runTerraformCmdJSON(ctx, showCmd, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -93,7 +93,7 @@ func (tf *Terraform) ShowStateFile(ctx context.Context, statePath string, opts .
 
 	var ret tfjson.State
 	ret.UseJSONNumber(true)
-	err = tf.runTerraformCmdJSON(showCmd, &ret)
+	err = tf.runTerraformCmdJSON(ctx, showCmd, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -135,7 +135,7 @@ func (tf *Terraform) ShowPlanFile(ctx context.Context, planPath string, opts ...
 	showCmd := tf.showCmd(ctx, true, mergeEnv, planPath)
 
 	var ret tfjson.Plan
-	err = tf.runTerraformCmdJSON(showCmd, &ret)
+	err = tf.runTerraformCmdJSON(ctx, showCmd, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -175,7 +175,7 @@ func (tf *Terraform) ShowPlanFileRaw(ctx context.Context, planPath string, opts 
 
 	var ret bytes.Buffer
 	showCmd.Stdout = &ret
-	err := tf.runTerraformCmd(showCmd)
+	err := tf.runTerraformCmd(ctx, showCmd)
 	if err != nil {
 		return "", err
 	}

--- a/tfexec/state_mv.go
+++ b/tfexec/state_mv.go
@@ -60,7 +60,7 @@ func (tf *Terraform) StateMv(ctx context.Context, source string, destination str
 	if err != nil {
 		return err
 	}
-	return tf.runTerraformCmd(cmd)
+	return tf.runTerraformCmd(ctx, cmd)
 }
 
 func (tf *Terraform) stateMvCmd(ctx context.Context, source string, destination string, opts ...StateMvCmdOption) (*exec.Cmd, error) {

--- a/tfexec/terraform.go
+++ b/tfexec/terraform.go
@@ -22,6 +22,12 @@ type printfer interface {
 // but you can override paths used in some commands depending on the available
 // options.
 //
+// All functions that execute CLI commands take a context.Context. It should be noted that
+// exec.Cmd.Run will not return context.DeadlineExceeded or context.Canceled by default, we
+// have augmented our wrapped errors to respond true to errors.Is for context.DeadlineExceeded
+// and context.Canceled if those are present on the context when the error is parsed. See
+// https://github.com/golang/go/issues/21880 for more about the Go limitations.
+//
 // By default, the instance inherits the environment from the calling code (using os.Environ)
 // but it ignores certain environment variables that are managed within the code and prohibits
 // setting them through SetEnv:
@@ -66,8 +72,9 @@ func NewTerraform(workingDir string, execPath string) (*Terraform, error) {
 
 	if execPath == "" {
 		err := fmt.Errorf("NewTerraform: please supply the path to a Terraform executable using execPath, e.g. using the tfinstall package.")
-		return nil, &ErrNoSuitableBinary{err: err}
-
+		return nil, &ErrNoSuitableBinary{
+			err: err,
+		}
 	}
 	tf := Terraform{
 		execPath:   execPath,

--- a/tfexec/upgrade012.go
+++ b/tfexec/upgrade012.go
@@ -40,7 +40,7 @@ func (tf *Terraform) Upgrade012(ctx context.Context, opts ...Upgrade012Option) e
 	if err != nil {
 		return err
 	}
-	return tf.runTerraformCmd(cmd)
+	return tf.runTerraformCmd(ctx, cmd)
 }
 
 func (tf *Terraform) upgrade012Cmd(ctx context.Context, opts ...Upgrade012Option) (*exec.Cmd, error) {

--- a/tfexec/validate.go
+++ b/tfexec/validate.go
@@ -22,14 +22,15 @@ func (tf *Terraform) Validate(ctx context.Context) (*tfjson.ValidateOutput, erro
 	var outbuf = bytes.Buffer{}
 	cmd.Stdout = &outbuf
 
-	err = tf.runTerraformCmd(cmd)
+	err = tf.runTerraformCmd(ctx, cmd)
 	// TODO: this command should not exit 1 if you pass -json as its hard to differentiate other errors
 	if err != nil && cmd.ProcessState.ExitCode() != 1 {
 		return nil, err
 	}
 
-	var out tfjson.ValidateOutput
-	jsonErr := json.Unmarshal(outbuf.Bytes(), &out)
+	var ret tfjson.ValidateOutput
+	// TODO: ret.UseJSONNumber(true) validate output should support JSON numbers
+	jsonErr := json.Unmarshal(outbuf.Bytes(), &ret)
 	if jsonErr != nil {
 		// the original call was possibly bad, if it has an error, actually just return that
 		if err != nil {
@@ -39,5 +40,5 @@ func (tf *Terraform) Validate(ctx context.Context) (*tfjson.ValidateOutput, erro
 		return nil, jsonErr
 	}
 
-	return &out, nil
+	return &ret, nil
 }

--- a/tfexec/version.go
+++ b/tfexec/version.go
@@ -44,7 +44,7 @@ func (tf *Terraform) version(ctx context.Context) (*version.Version, map[string]
 	var outBuf bytes.Buffer
 	versionCmd.Stdout = &outBuf
 
-	err := tf.runTerraformCmd(versionCmd)
+	err := tf.runTerraformCmd(ctx, versionCmd)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/tfexec/workspace_list.go
+++ b/tfexec/workspace_list.go
@@ -14,7 +14,7 @@ func (tf *Terraform) WorkspaceList(ctx context.Context) ([]string, string, error
 	var outBuf bytes.Buffer
 	wlCmd.Stdout = &outBuf
 
-	err := tf.runTerraformCmd(wlCmd)
+	err := tf.runTerraformCmd(ctx, wlCmd)
 	if err != nil {
 		return nil, "", err
 	}

--- a/tfexec/workspace_new.go
+++ b/tfexec/workspace_new.go
@@ -41,7 +41,7 @@ func (tf *Terraform) WorkspaceNew(ctx context.Context, workspace string, opts ..
 	if err != nil {
 		return err
 	}
-	return tf.runTerraformCmd(cmd)
+	return tf.runTerraformCmd(ctx, cmd)
 }
 
 func (tf *Terraform) workspaceNewCmd(ctx context.Context, workspace string, opts ...WorkspaceNewCmdOption) (*exec.Cmd, error) {

--- a/tfexec/workspace_select.go
+++ b/tfexec/workspace_select.go
@@ -6,5 +6,5 @@ import "context"
 func (tf *Terraform) WorkspaceSelect(ctx context.Context, workspace string) error {
 	// TODO: [DIR] param option
 
-	return tf.runTerraformCmd(tf.buildTerraformCmd(ctx, nil, "workspace", "select", "-no-color", workspace))
+	return tf.runTerraformCmd(ctx, tf.buildTerraformCmd(ctx, nil, "workspace", "select", "-no-color", workspace))
 }


### PR DESCRIPTION
This potentially supersedes #91 

Probably best to review individual commits, the first commit splits exported errors to two files, one for exit error wrappers and one for the rest. No other changes beyond comments. The second commit adds the support for unwrapping and `errors.Is` comparisons.