### PR TITLE
Support long terraform variable names in ErrMissingVar

### DIFF
--- a/tfexec/errors.go
+++ b/tfexec/errors.go
@@ -11,7 +11,7 @@ import (
 var (
 	// The "Required variable not set:" case is for 0.11
 	missingVarErrRegexp  = regexp.MustCompile(`Error: No value for required variable|Error: Required variable not set:`)
-	missingVarNameRegexp = regexp.MustCompile(`The root module input variable "(.+)" is not set, and has no default|Error: Required variable not set: (.+)`)
+	missingVarNameRegexp = regexp.MustCompile(`The root module input variable\s"(.+)"\sis\snot\sset,\sand\shas\sno\sdefault|Error: Required variable not set: (.+)`)
 
 	usageRegexp = regexp.MustCompile(`Too many command line arguments|^Usage: .*Options:.*|Error: Invalid -\d+ option`)
 

--- a/tfexec/internal/e2etest/testdata/var/main.tf
+++ b/tfexec/internal/e2etest/testdata/var/main.tf
@@ -3,4 +3,7 @@ variable "default" {
 }
 
 variable "no_default" {
-} 
+}
+
+variable "no_default_really_long_variable_name_that_will_line_wrap_tf_output" {
+}


### PR DESCRIPTION
An issue currently exists when a terraform variable with a very long name has no value. In these cases, the error message returned from tfexec/errors.go doesn't include the name of the terraform variable that is causing the problem. This is because terraform attempts to make error messages fit the terminal width, which means error messages can have a newline character instead of a space depending on the length of the variable name, and therefore the error message regex in terraform-exec doesn't match properly. This PR fixes this behavior to correctly display error messages no matter the length of the terraform variable name by matching on "\s" instead of " ".

This issue doesn't appear to be a problem with the Terraform 0.11 regex because of how much shorter the error message is.

To illustrate the problem, you can see the output when running the e2etest added in this PR without the fix to the regex in errors.go being in place:

> errors_test.go:74: expected missing no_default_really_long_variable_name_that_will_line_wrap_tf_output, got ""

