### PR TITLE
Update git ref test

### DIFF
--- a/tfinstall/gitref/git_ref_test.go
+++ b/tfinstall/gitref/git_ref_test.go
@@ -36,7 +36,7 @@ func TestGitRef(t *testing.T) {
 		// https://github.com/hashicorp/terraform/pull/25633
 		"PR 25633": {"Terraform v0.12.29-dev", "refs/pull/25633/head"},
 		//"commit 83630a7": {"Terraform v0.12.29", "83630a7003fb8b868a3bf940798326634c3c6acc"},
-		"empty": {"Terraform v0.14.", ""}, // should pull master, which is currently 0.14 dev
+		"empty": {"Terraform v0.15.", ""}, // should pull master, which is currently 0.15 dev
 	} {
 		c := c
 		t.Run(n, func(t *testing.T) {

--- a/tfinstall/gitref/git_ref_test.go
+++ b/tfinstall/gitref/git_ref_test.go
@@ -33,9 +33,7 @@ func TestGitRef(t *testing.T) {
 	}{
 		"branch v0.12": {"Terraform v0.12.", "refs/heads/v0.12"},
 		"tag v0.12.29": {"Terraform v0.12.29", "refs/tags/v0.12.29"},
-		// https://github.com/hashicorp/terraform/pull/25633
-		"PR 25633": {"Terraform v0.12.29-dev", "refs/pull/25633/head"},
-		//"commit 83630a7": {"Terraform v0.12.29", "83630a7003fb8b868a3bf940798326634c3c6acc"},
+		// "commit 83630a7": {"Terraform v0.12.29", "83630a7003fb8b868a3bf940798326634c3c6acc"},
 		"empty": {"Terraform v0.15.", ""}, // should pull master, which is currently 0.15 dev
 	} {
 		c := c


### PR DESCRIPTION
As of https://github.com/hashicorp/terraform/commit/24d6c74e97430f4d0d78e879b487392fbf07914b, `master` on Core is now set to 0.15. Update tfinstall's git ref test to reflect this.

The `PR 25633` (https://github.com/hashicorp/terraform/pull/25633) test case started failing when the PR's branch was deleted 7 days ago. Since we can't predict when this will happen, I've removed the test case. I think we can be sure that if the other `refs/` cases work, PRs will too.

The commented-out test case `commit 83630a7` will be addressed in https://github.com/hashicorp/hcinstall/issues/1.