### PR TITLE
Use json.Number instead of float64 when parsing state.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/hashicorp/go-getter v1.4.0
 	github.com/hashicorp/go-version v1.2.1
 	github.com/hashicorp/logutils v1.0.0
-	github.com/hashicorp/terraform-json v0.7.0
+	github.com/hashicorp/terraform-json v0.7.1-0.20201216193920-93fe74c2941e
 	github.com/mitchellh/cli v1.1.1
 	github.com/sergi/go-diff v1.1.0
 	github.com/stretchr/testify v1.6.1

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/hashicorp/go-getter v1.4.0
 	github.com/hashicorp/go-version v1.2.1
 	github.com/hashicorp/logutils v1.0.0
-	github.com/hashicorp/terraform-json v0.7.1-0.20201216193920-93fe74c2941e
+	github.com/hashicorp/terraform-json v0.7.1-0.20201216214122-860b31cbd2be
 	github.com/mitchellh/cli v1.1.1
 	github.com/sergi/go-diff v1.1.0
 	github.com/stretchr/testify v1.6.1

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/hashicorp/go-getter v1.4.0
 	github.com/hashicorp/go-version v1.2.1
 	github.com/hashicorp/logutils v1.0.0
-	github.com/hashicorp/terraform-json v0.7.1-0.20201216214122-860b31cbd2be
+	github.com/hashicorp/terraform-json v0.8.0
 	github.com/mitchellh/cli v1.1.1
 	github.com/sergi/go-diff v1.1.0
 	github.com/stretchr/testify v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -95,8 +95,8 @@ github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
-github.com/hashicorp/terraform-json v0.7.1-0.20201216214122-860b31cbd2be h1:ije30JtxEulgLUV8/nwNF3cfQsRQa67dczGEYJLL6e4=
-github.com/hashicorp/terraform-json v0.7.1-0.20201216214122-860b31cbd2be/go.mod h1:3defM4kkMfttwiE7VakJDwCd4R+umhSQnvJwORXbprE=
+github.com/hashicorp/terraform-json v0.8.0 h1:XObQ3PgqU52YLQKEaJ08QtUshAfN3yu4u8ebSW0vztc=
+github.com/hashicorp/terraform-json v0.8.0/go.mod h1:3defM4kkMfttwiE7VakJDwCd4R+umhSQnvJwORXbprE=
 github.com/imdario/mergo v0.3.9 h1:UauaLniWCFHWd+Jp9oCEkTBj8VO/9DKg3PV3VCNMDIg=
 github.com/imdario/mergo v0.3.9/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=

--- a/go.sum
+++ b/go.sum
@@ -95,8 +95,8 @@ github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
-github.com/hashicorp/terraform-json v0.7.1-0.20201216193920-93fe74c2941e h1:eRFeH76HcGTdZ0+Y/tG4BoVUKEg52rXPf9aPDd1DGHU=
-github.com/hashicorp/terraform-json v0.7.1-0.20201216193920-93fe74c2941e/go.mod h1:3defM4kkMfttwiE7VakJDwCd4R+umhSQnvJwORXbprE=
+github.com/hashicorp/terraform-json v0.7.1-0.20201216214122-860b31cbd2be h1:ije30JtxEulgLUV8/nwNF3cfQsRQa67dczGEYJLL6e4=
+github.com/hashicorp/terraform-json v0.7.1-0.20201216214122-860b31cbd2be/go.mod h1:3defM4kkMfttwiE7VakJDwCd4R+umhSQnvJwORXbprE=
 github.com/imdario/mergo v0.3.9 h1:UauaLniWCFHWd+Jp9oCEkTBj8VO/9DKg3PV3VCNMDIg=
 github.com/imdario/mergo v0.3.9/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=

--- a/go.sum
+++ b/go.sum
@@ -95,10 +95,8 @@ github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
-github.com/hashicorp/terraform-json v0.5.0 h1:7TV3/F3y7QVSuN4r9BEXqnWqrAyeOtON8f0wvREtyzs=
-github.com/hashicorp/terraform-json v0.5.0/go.mod h1:eAbqb4w0pSlRmdvl8fOyHAi/+8jnkVYN28gJkSJrLhU=
-github.com/hashicorp/terraform-json v0.7.0 h1:DgkfLARKMQ/xmzVtSRX9Vz/fzPCL3vskHIgj6s+SQwQ=
-github.com/hashicorp/terraform-json v0.7.0/go.mod h1:3defM4kkMfttwiE7VakJDwCd4R+umhSQnvJwORXbprE=
+github.com/hashicorp/terraform-json v0.7.1-0.20201216193920-93fe74c2941e h1:eRFeH76HcGTdZ0+Y/tG4BoVUKEg52rXPf9aPDd1DGHU=
+github.com/hashicorp/terraform-json v0.7.1-0.20201216193920-93fe74c2941e/go.mod h1:3defM4kkMfttwiE7VakJDwCd4R+umhSQnvJwORXbprE=
 github.com/imdario/mergo v0.3.9 h1:UauaLniWCFHWd+Jp9oCEkTBj8VO/9DKg3PV3VCNMDIg=
 github.com/imdario/mergo v0.3.9/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=

--- a/tfexec/cmd.go
+++ b/tfexec/cmd.go
@@ -189,7 +189,9 @@ func (tf *Terraform) runTerraformCmdJSON(cmd *exec.Cmd, v interface{}) error {
 		return err
 	}
 
-	return json.Unmarshal(outbuf.Bytes(), v)
+	dec := json.NewDecoder(&outbuf)
+	dec.UseNumber()
+	return dec.Decode(v)
 }
 
 func (tf *Terraform) runTerraformCmd(cmd *exec.Cmd) error {

--- a/tfexec/internal/e2etest/cmp.go
+++ b/tfexec/internal/e2etest/cmp.go
@@ -12,7 +12,7 @@ import (
 // diffState returns a human-readable report of the differences between two
 // state values. It returns an empty string if the two values are equal.
 func diffState(expected *tfjson.State, actual *tfjson.State) string {
-	return cmp.Diff(expected, actual, cmpopts.IgnoreFields(tfjson.State{}, "TerraformVersion"))
+	return cmp.Diff(expected, actual, cmpopts.IgnoreFields(tfjson.State{}, "TerraformVersion"), cmpopts.IgnoreFields(tfjson.State{}, "useJSONNumber"))
 }
 
 // diffPlan returns a human-readable report of the differences between two

--- a/tfexec/show.go
+++ b/tfexec/show.go
@@ -49,6 +49,7 @@ func (tf *Terraform) Show(ctx context.Context, opts ...ShowOption) (*tfjson.Stat
 	showCmd := tf.showCmd(ctx, true, mergeEnv)
 
 	var ret tfjson.State
+	ret.UseJSONNumber(true)
 	err = tf.runTerraformCmdJSON(showCmd, &ret)
 	if err != nil {
 		return nil, err
@@ -91,6 +92,7 @@ func (tf *Terraform) ShowStateFile(ctx context.Context, statePath string, opts .
 	showCmd := tf.showCmd(ctx, true, mergeEnv, statePath)
 
 	var ret tfjson.State
+	ret.UseJSONNumber(true)
 	err = tf.runTerraformCmdJSON(showCmd, &ret)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
State values can contain numbers that are larger than `float64` can
precisely represent. `json.Unmarshal` when unmarshaled into an
`interface{}` uses `float64` to represent numbers by default. To
properly retain precision for numbers, we need to use a custom
`json.Decoder` with the `UseNumber()` method called on it, which will
use `json.Number` (a `string` alias) to store the numbers, preserving
their precision.

This does this at the `runTerraformCmdJSON` level, meaning anyone using that method with `v` as `interface{}` in the arguments will suddenly find that their `float64`s are now `json.Number`s, which may break them. The solution to this is to use the `Float64()` method on the `json.Number`, but it is a code change they will need to make.