### PR TITLE
Handle terraform init flags removed in 0.15

### DIFF
--- a/tfexec/init.go
+++ b/tfexec/init.go
@@ -105,6 +105,14 @@ func (tf *Terraform) initCmd(ctx context.Context, opts ...InitOption) (*exec.Cmd
 	c := defaultInitOptions
 
 	for _, o := range opts {
+		switch o.(type) {
+		case *LockOption, *LockTimeoutOption, *VerifyPluginsOption, *GetPluginsOption:
+			err := tf.compatible(ctx, nil, tf0_15_0)
+			if err != nil {
+				return nil, fmt.Errorf("-lock, -lock-timeout, -verify-plugins, and -get-plugins options are no longer available as of Terraform 0.15: %w", err)
+			}
+		}
+
 		o.configureInit(&c)
 	}
 
@@ -114,17 +122,27 @@ func (tf *Terraform) initCmd(ctx context.Context, opts ...InitOption) (*exec.Cmd
 	if c.fromModule != "" {
 		args = append(args, "-from-module="+c.fromModule)
 	}
-	if c.lockTimeout != "" {
-		args = append(args, "-lock-timeout="+c.lockTimeout)
+
+	// string opts removed in 0.15: pass if set and <0.15
+	err := tf.compatible(ctx, nil, tf0_15_0)
+	if err == nil {
+		if c.lockTimeout != "" {
+			args = append(args, "-lock-timeout="+c.lockTimeout)
+		}
 	}
 
 	// boolean opts: always pass
 	args = append(args, "-backend="+fmt.Sprint(c.backend))
 	args = append(args, "-get="+fmt.Sprint(c.get))
-	args = append(args, "-get-plugins="+fmt.Sprint(c.getPlugins))
-	args = append(args, "-lock="+fmt.Sprint(c.lock))
 	args = append(args, "-upgrade="+fmt.Sprint(c.upgrade))
-	args = append(args, "-verify-plugins="+fmt.Sprint(c.verifyPlugins))
+
+	// boolean opts removed in 0.15: pass if <0.15
+	err = tf.compatible(ctx, nil, tf0_15_0)
+	if err == nil {
+		args = append(args, "-lock="+fmt.Sprint(c.lock))
+		args = append(args, "-get-plugins="+fmt.Sprint(c.getPlugins))
+		args = append(args, "-verify-plugins="+fmt.Sprint(c.verifyPlugins))
+	}
 
 	// unary flags: pass if true
 	if c.reconfigure {

--- a/tfexec/init_test.go
+++ b/tfexec/init_test.go
@@ -33,9 +33,9 @@ func TestInitCmd(t *testing.T) {
 			"-lock-timeout=0s",
 			"-backend=true",
 			"-get=true",
-			"-get-plugins=true",
-			"-lock=true",
 			"-upgrade=false",
+			"-lock=true",
+			"-get-plugins=true",
 			"-verify-plugins=true",
 		}, nil, initCmd)
 	})
@@ -55,9 +55,9 @@ func TestInitCmd(t *testing.T) {
 			"-lock-timeout=999s",
 			"-backend=false",
 			"-get=false",
-			"-get-plugins=false",
-			"-lock=false",
 			"-upgrade=true",
+			"-lock=false",
+			"-get-plugins=false",
 			"-verify-plugins=false",
 			"-reconfigure",
 			"-backend-config=confpath1",

--- a/tfexec/internal/e2etest/import_test.go
+++ b/tfexec/internal/e2etest/import_test.go
@@ -18,13 +18,13 @@ func TestImport(t *testing.T) {
 	runTest(t, "import", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
 		ctx := context.Background()
 
-		err := tf.Init(ctx, tfexec.Lock(false))
+		err := tf.Init(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		// Config is unnecessary here since its already the working dir, but just testing an additional flag
-		err = tf.Import(ctx, resourceAddress, expectedID, tfexec.DisableBackup(), tfexec.Lock(false), tfexec.Config(tf.WorkingDir()))
+		err = tf.Import(ctx, resourceAddress, expectedID, tfexec.DisableBackup(), tfexec.Config(tf.WorkingDir()))
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/tfexec/internal/e2etest/version_test.go
+++ b/tfexec/internal/e2etest/version_test.go
@@ -13,7 +13,7 @@ func TestVersion(t *testing.T) {
 	runTest(t, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
 		ctx := context.Background()
 
-		err := tf.Init(ctx, tfexec.Lock(false))
+		err := tf.Init(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/tfexec/terraform_test.go
+++ b/tfexec/terraform_test.go
@@ -97,9 +97,9 @@ func TestCheckpointDisablePropagation(t *testing.T) {
 			"-lock-timeout=0s",
 			"-backend=true",
 			"-get=true",
-			"-get-plugins=true",
-			"-lock=true",
 			"-upgrade=false",
+			"-lock=true",
+			"-get-plugins=true",
 			"-verify-plugins=true",
 		}, map[string]string{
 			"CHECKPOINT_DISABLE": "1",
@@ -129,9 +129,9 @@ func TestCheckpointDisablePropagation(t *testing.T) {
 			"-lock-timeout=0s",
 			"-backend=true",
 			"-get=true",
-			"-get-plugins=true",
-			"-lock=true",
 			"-upgrade=false",
+			"-lock=true",
+			"-get-plugins=true",
 			"-verify-plugins=true",
 		}, map[string]string{
 			"CHECKPOINT_DISABLE": "",

--- a/tfexec/version.go
+++ b/tfexec/version.go
@@ -15,6 +15,7 @@ var (
 	tf0_7_7  = version.Must(version.NewVersion("0.7.7"))
 	tf0_12_0 = version.Must(version.NewVersion("0.12.0"))
 	tf0_13_0 = version.Must(version.NewVersion("0.13.0"))
+	tf0_15_0 = version.Must(version.NewVersion("0.15.0"))
 )
 
 // Version returns structured output from the terraform version command including both the Terraform CLI version


### PR DESCRIPTION
From the Terraform 0.15 CHANGELOG:

* The `-lock` and `-lock-timeout` options are no longer available on `terraform init` [GH-27464]
* The `-verify-plugins=false` option is no longer available on `terraform init`. (Terraform now _always_ verifies plugins.) [GH-27461]
* The `-get-plugins=false` option is no longer available on `terraform init`. (Terraform now _always_ installs plugins.) [GH-27463]

This PR adds a compatibility error if the user attempts to set these options when using Terraform 0.15 and above. We maintain the existing behaviour of passing default values for these options prior to 0.15.

This fixes the errors seen in the nightly `master` test run ([example](https://app.circleci.com/pipelines/github/hashicorp/terraform-exec/623/workflows/d5b12efb-9755-4833-ac5e-08bf51f6b381/jobs/9136)).