### PR TITLE
Notify on nightly success as well as failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -252,12 +252,7 @@ workflows:
               only:
                 - master
     jobs:
-      - winbuildtest:
-          context: terraform-exec-slack-notifications
-          post-steps:
-            - slack/notify:
-                event: fail
-                template: basic_fail_1
+      - winbuildtest
       - macosbuildtest:
           context: terraform-exec-slack-notifications
           post-steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -305,6 +305,28 @@ workflows:
             - slack/notify:
                 event: fail
                 template: basic_fail_1
-                channel: C012ZU33BEE
+            - slack/notify:
+                event: pass
+                custom: |
+                  {
+                    "blocks": [
+                      {
+                        "type": "section",
+                        "fields": [
+                          {
+                            "type": "plain_text",
+                            "text": ":terraform-da: The nightly test run passed. :terraformda:",
+                            "emoji": true
+                          }
+                        ]
+                      }
+                    ]
+                  }
           requires:
             - go115_build
+            - go115_test
+            - go114_test
+            - go113_build
+            - go112_build
+            - winbuildtest
+            - macosbuildtest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -254,31 +254,26 @@ workflows:
     jobs:
       - winbuildtest
       - macosbuildtest:
-          context: terraform-exec-slack-notifications
           post-steps:
             - slack/notify:
                 event: fail
                 template: basic_fail_1
       - go112_build:
-          context: terraform-exec-slack-notifications
           post-steps:
             - slack/notify:
                 event: fail
                 template: basic_fail_1
       - go113_build:
-          context: terraform-exec-slack-notifications
           post-steps:
             - slack/notify:
                 event: fail
                 template: basic_fail_1
       - go114_build:
-          context: terraform-exec-slack-notifications
           post-steps:
             - slack/notify:
                 event: fail
                 template: basic_fail_1
       - go114_test:
-          context: terraform-exec-slack-notifications
           post-steps:
             - slack/notify:
                 event: fail
@@ -286,13 +281,11 @@ workflows:
           requires:
             - go114_build
       - go115_build:
-          context: terraform-exec-slack-notifications
           post-steps:
             - slack/notify:
                 event: fail
                 template: basic_fail_1
       - go115_test:
-          context: terraform-exec-slack-notifications
           post-steps:
             - slack/notify:
                 event: fail
@@ -300,7 +293,6 @@ workflows:
           requires:
             - go115_build
       - go115_test_master:
-          context: terraform-exec-slack-notifications
           post-steps:
             - slack/notify:
                 event: fail


### PR DESCRIPTION
Also:
-  Remove Slack notification step from Windows build jobs, because it doesn't work with the Windows build agent (known issue with CircleCI orb: https://github.com/CircleCI-Public/slack-orb/issues/208, https://github.com/CircleCI-Public/slack-orb/issues/217).
- Remove use of CircleCI contexts to import environment variables, due to change by Release Engineering.


The success notification has been tested.