### PR TITLE
Update branch references

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,9 +96,9 @@ jobs:
     steps:
       - checkout
       - go_test
-  go115_test_master:
+  go115_test_main:
     environment:
-      TFEXEC_E2ETEST_VERSIONS: refs/heads/master
+      TFEXEC_E2ETEST_VERSIONS: refs/heads/main
     docker:
       - image: circleci/golang:1.15
     parameters:
@@ -162,77 +162,77 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - main
       - macosbuildtest:
           filters:
             branches:
               only:
-                - master
+                - main
 
       # build only for these versions
       - go112_build:
           filters:
             branches:
               only:
-                - master
+                - main
       - go113_build:
           filters:
             branches:
               only:
-                - master
+                - main
 
       - go114_build:
           filters:
             branches:
               only:
-                - master
+                - main
       - go114_test:
           requires:
             - go114_build
           filters:
             branches:
               only:
-                - master
+                - main
 
       - go115_build:
           filters:
             branches:
               only:
-                - master
+                - main
       - go115_test:
           requires:
             - go115_build
           filters:
             branches:
               only:
-                - master
+                - main
       - go115_vet:
           requires:
             - go115_build
           filters:
             branches:
               only:
-                - master
+                - main
       - go115_fmt:
           requires:
             - go115_build
           filters:
             branches:
               only:
-                - master
+                - main
 
       - trigger-release:
           filters:
             branches:
               only:
-                - master
+                - main
           type: approval
 
       - go115_release:
           filters:
             branches:
               only:
-                - master
+                - main
           requires:
             - trigger-release
             - go112_build
@@ -250,7 +250,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - main
     jobs:
       - winbuildtest
       - macosbuildtest:
@@ -292,7 +292,7 @@ workflows:
                 template: basic_fail_1
           requires:
             - go115_build
-      - go115_test_master:
+      - go115_test_main:
           post-steps:
             - slack/notify:
                 event: fail

--- a/cmd/tfinstall/main.go
+++ b/cmd/tfinstall/main.go
@@ -67,7 +67,7 @@ Examples:
   tfinstall latest
   tfinstall 0.13.0-beta3
   tfinstall --dir=/home/kmoe/bin 0.12.28
-  tfinstall refs/heads/master
+  tfinstall refs/heads/main
   tfinstall refs/tags/v0.12.29
   tfinstall refs/pull/25633/head
 `

--- a/tfexec/internal/e2etest/util_test.go
+++ b/tfexec/internal/e2etest/util_test.go
@@ -18,7 +18,6 @@ import (
 )
 
 const testFixtureDir = "testdata"
-const masterRef = "refs/heads/master"
 
 var (
 	showMinVersion = version.Must(version.NewVersion("0.12.0"))

--- a/tfinstall/gitref/git_ref.go
+++ b/tfinstall/gitref/git_ref.go
@@ -36,7 +36,7 @@ func (opt *Option) ExecPath(ctx context.Context) (string, error) {
 
 	ref := plumbing.ReferenceName(opt.ref)
 	if opt.ref == "" {
-		ref = plumbing.ReferenceName("refs/heads/master")
+		ref = plumbing.ReferenceName("refs/heads/main")
 	}
 
 	repoURL := opt.repoURL

--- a/tfinstall/gitref/git_ref_test.go
+++ b/tfinstall/gitref/git_ref_test.go
@@ -34,7 +34,7 @@ func TestGitRef(t *testing.T) {
 		"branch v0.12": {"Terraform v0.12.", "refs/heads/v0.12"},
 		"tag v0.12.29": {"Terraform v0.12.29", "refs/tags/v0.12.29"},
 		// "commit 83630a7": {"Terraform v0.12.29", "83630a7003fb8b868a3bf940798326634c3c6acc"},
-		"empty": {"Terraform v0.15.", ""}, // should pull master, which is currently 0.15 dev
+		"empty": {"Terraform v0.15.", ""}, // should pull main, which is currently 0.15 dev
 	} {
 		c := c
 		t.Run(n, func(t *testing.T) {


### PR DESCRIPTION
Terraform Core has renamed its main branch to `main`. Update references to that branch within terraform-exec, and rename our own branch to match.