### PR TITLE
Update readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ func main() {
 	}
 	defer os.RemoveAll(tmpDir)
 
-	execPath, err := tfinstall.Find(tfinstall.LatestVersion(tmpDir, false))
+	execPath, err := tfinstall.Find(context.Background(), tfinstall.LatestVersion(tmpDir, false))
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
The current syntax in the README doesn't work.
`tfinstall.Find` is missing one argument in the function call.
This PR adds `context.Background()` as an additional parameter.

Nic