### PR TITLE
Fix validate test in 0.15 prereleases

### DIFF
--- a/tfexec/internal/e2etest/validate_test.go
+++ b/tfexec/internal/e2etest/validate_test.go
@@ -57,7 +57,8 @@ func TestValidate(t *testing.T) {
 
 		var expectedDiags []tfjson.Diagnostic
 
-		if tfv.GreaterThanOrEqual(version.Must(version.NewVersion("0.15.0"))) {
+		// TODO: Once 0.15.0 is released, remove the extra -beta2 and -dev conditions.
+		if tfv.GreaterThanOrEqual(version.Must(version.NewVersion("0.15.0"))) || tfv.Equal(version.Must(version.NewVersion("0.15.0-beta2"))) || tfv.Equal(version.Must(version.NewVersion("0.15.0-dev"))) {
 			expectedDiags = []tfjson.Diagnostic{
 				{
 					Severity: "error",


### PR DESCRIPTION
As discussed elsewhere, versions such as `0.15.0-beta2` and `0.15.0-dev` do not satisfy the condition `tfv.GreaterThanOrEqual(version.Must(version.NewVersion("0.15.0")))`. A proposal will be made separately to `go-version` to provide prerelease-compatible comparison functions. In the meantime, hardcode the beta and nightly version numbers into the test so both tests pass.