### PR TITLE
hack: fix provider schema test in 0.15 prereleases

### DIFF
--- a/tfexec/internal/e2etest/providers_schema_test.go
+++ b/tfexec/internal/e2etest/providers_schema_test.go
@@ -25,7 +25,7 @@ func TestProvidersSchema(t *testing.T) {
 			"basic", func(tfv *version.Version) *tfjson.ProviderSchemas {
 				var providerSchema *tfjson.ProviderSchemas
 
-				if tfv.GreaterThanOrEqual(version.Must(version.NewVersion("0.15.0"))) {
+				if tfv.GreaterThanOrEqual(version.Must(version.NewVersion("0.15.0"))) || tfv.Equal(version.Must(version.NewVersion("0.15.0-beta2"))) || tfv.Equal(version.Must(version.NewVersion("0.15.0-dev"))) {
 					providerSchema = &tfjson.ProviderSchemas{
 						FormatVersion: "0.2",
 						Schemas: map[string]*tfjson.ProviderSchema{


### PR DESCRIPTION
This is to fix the following nightly failure:

```diff
- 	FormatVersion: "0.1",
+ 	FormatVersion: "0.2",
```
```
--- FAIL: TestProvidersSchema (1.30s)
    --- FAIL: TestProvidersSchema/0_basic (0.89s)
        --- FAIL: TestProvidersSchema/0_basic/basic-refs/heads/main (0.89s)
    --- FAIL: TestProvidersSchema/1_empty_with_tf_file (0.40s)
        --- FAIL: TestProvidersSchema/1_empty_with_tf_file/empty_with_tf_file-refs/heads/main (0.40s)
```