### PR TITLE
circle: Run brew update before installing go

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,12 +14,13 @@ commands:
   macos_install_go:
     steps:
       - run:
-          # just latest stable version of Go as a sanity check
-          # version specification would require a brew update probably
-          # so this keeps it faster
-          command: |
-            brew install golang
-            go version
+          # Ensure we have the latest Homebrew revision
+          # which downloads from GitHub, not Bintray
+          command: brew update
+      - run:
+          command: brew install golang
+      - run:
+          command: go version
 
   go_build:
     steps:


### PR DESCRIPTION
This is to address installation failure observed last night: https://app.circleci.com/pipelines/github/hashicorp/terraform-exec/855/workflows/4f4a773f-e4d4-4991-8a0a-a075560601d1/jobs/11437