### PR TITLE
Create a constant for the binary file name

### DIFF
--- a/tfinstall/download.go
+++ b/tfinstall/download.go
@@ -92,7 +92,7 @@ func downloadWithVerification(ctx context.Context, tfVersion string, installDir 
 		return "", err
 	}
 
-	return filepath.Join(tfDir, "terraform"), nil
+	return filepath.Join(tfDir, BinaryFileName), nil
 }
 
 // verifySumsSignature downloads SHA256SUMS and SHA256SUMS.sig and verifies

--- a/tfinstall/look_path.go
+++ b/tfinstall/look_path.go
@@ -18,7 +18,7 @@ func LookPath() *LookPathOption {
 }
 
 func (opt *LookPathOption) ExecPath(context.Context) (string, error) {
-	p, err := exec.LookPath("terraform")
+	p, err := exec.LookPath(BinaryFileName)
 	if err != nil {
 		if notFoundErr, ok := err.(*exec.Error); ok && notFoundErr.Err == exec.ErrNotFound {
 			log.Printf("[WARN] could not locate a terraform executable on system path; continuing")

--- a/tfinstall/tfinstall.go
+++ b/tfinstall/tfinstall.go
@@ -7,6 +7,10 @@ import (
 	"strings"
 )
 
+const (
+	BinaryFileName = "terraform"
+)
+
 const baseURL = "https://releases.hashicorp.com/terraform"
 
 type ExecPathFinder interface {


### PR DESCRIPTION
As a user, I'd like to predicate the binary file name tfexec will try to execute. This can be useful when you need to install multiple versions of Terraform at the same time in different directories but install each version only once. If that binary file name might change in the future, I don't want my code to fail because of that. Is that something relevant to you? May be I missed a method to achieve that differently, let me know!

### References

- https://github.com/cloudskiff/driftctl/pull/416