### PR TITLE
Added documentation on exact_version.go

### DIFF
--- a/tfinstall/exact_version.go
+++ b/tfinstall/exact_version.go
@@ -15,6 +15,9 @@ type ExactVersionOption struct {
 
 var _ ExecPathFinder = &ExactVersionOption{}
 
+// ExactVersion returns a pointer to an ExactVersionOption object specifying a terraform version and installation directory passed to the function
+// Since ExactVersionOption is exported, it can also be instantiated manually
+// Manual instantiation of ExactVersionOption will be necessary if a custom UserAgent is required
 func ExactVersion(tfVersion string, installDir string) *ExactVersionOption {
 	opt := &ExactVersionOption{
 		tfVersion:  tfVersion,
@@ -24,6 +27,12 @@ func ExactVersion(tfVersion string, installDir string) *ExactVersionOption {
 	return opt
 }
 
+// ExecPath downloads a given Terraform binary at a given path
+// The binary is downloaded from the official terraform release platform (currently https://releases.hashicorp.com/terraform)
+// The version of the binary must be specified via the *ExactVersionOption object that this method is called on
+// The path where the binary is downloaded must be specified via the *ExactVersionOption object that this method is called on
+// It verifies the integrity of the binary via its checksum
+// It returns the path where the binary was downloadeds
 func (opt *ExactVersionOption) ExecPath(ctx context.Context) (string, error) {
 	// validate version
 	_, err := version.NewVersion(opt.tfVersion)


### PR DESCRIPTION
I find `tfinstall` a bit underdocumented. None of its methods or function has comments, cf [its official documentation](https://pkg.go.dev/github.com/hashicorp/terraform-exec/tfinstall).

I needed to understand the role and behavior of some function / method, so I added documentation.

Comments welcome.