### PR TITLE
Introduce tfexec.Get() for downloading modules

### DIFF
--- a/tfexec/get.go
+++ b/tfexec/get.go
@@ -1,0 +1,52 @@
+package tfexec
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+)
+
+type getCmdConfig struct {
+	dir    string
+	update bool
+}
+
+// GetCmdOption represents options used in the Get method.
+type GetCmdOption interface {
+	configureGet(*getCmdConfig)
+}
+
+func (opt *DirOption) configureGet(conf *getCmdConfig) {
+	conf.dir = opt.path
+}
+
+func (opt *UpdateOption) configureGet(conf *getCmdConfig) {
+	conf.update = opt.update
+}
+
+// Get represents the terraform get subcommand.
+func (tf *Terraform) Get(ctx context.Context, opts ...GetCmdOption) error {
+	cmd, err := tf.getCmd(ctx, opts...)
+	if err != nil {
+		return err
+	}
+	return tf.runTerraformCmd(ctx, cmd)
+}
+
+func (tf *Terraform) getCmd(ctx context.Context, opts ...GetCmdOption) (*exec.Cmd, error) {
+	c := getCmdConfig{}
+
+	for _, o := range opts {
+		o.configureGet(&c)
+	}
+
+	args := []string{"get", "-no-color"}
+
+	args = append(args, "-update="+fmt.Sprint(c.update))
+
+	if c.dir != "" {
+		args = append(args, c.dir)
+	}
+
+	return tf.buildTerraformCmd(ctx, nil, args...), nil
+}

--- a/tfexec/get_test.go
+++ b/tfexec/get_test.go
@@ -1,0 +1,33 @@
+package tfexec
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-exec/tfexec/internal/testutil"
+)
+
+func TestGetCmd(t *testing.T) {
+	td := testTempDir(t)
+
+	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest012))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// empty env, to avoid environ mismatch in testing
+	tf.SetEnv(map[string]string{})
+
+	t.Run("basic", func(t *testing.T) {
+		getCmd, err := tf.getCmd(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assertCmd(t, []string{
+			"get",
+			"-no-color",
+			"-update=false",
+		}, nil, getCmd)
+	})
+}

--- a/tfexec/options.go
+++ b/tfexec/options.go
@@ -289,6 +289,14 @@ func Target(resource string) *TargetOption {
 	return &TargetOption{resource}
 }
 
+type UpdateOption struct {
+	update bool
+}
+
+func Update(update bool) *UpdateOption {
+	return &UpdateOption{update}
+}
+
 type UpgradeOption struct {
 	upgrade bool
 }


### PR DESCRIPTION
Generally it is possible and _probably common_ to use the `init` command to _initialize_ a Terraform module, which will install providers, setup remote state backend and download modules.

Sometimes it may be desirable to avoid installing providers, or initializing backends. I have one particular use case in tests for Terraform LS where I'd like to create a "mock module manifest" so that I can test some other functionality which relies on that module manifest, without having to copy around that module manifest statically. i.e. I'd like to generate "test data" programmatically via `tfexec.Get()`, but then mock out the rest of terraform commands.

I can't think of too many other use cases at this point, but the `get` command doesn't seem to be going anywhere [based on docs](https://www.terraform.io/docs/cli/commands/get.html) at least, so I think it's worth supporting it.