### PR TITLE
add ProtocolVersion to ReattachConfig

### DIFF
--- a/tfexec/options.go
+++ b/tfexec/options.go
@@ -207,10 +207,11 @@ type ReattachInfo map[string]ReattachConfig
 // ReattachConfig holds the information Terraform needs to be able to attach
 // itself to a provider process, so it can drive the process.
 type ReattachConfig struct {
-	Protocol string
-	Pid      int
-	Test     bool
-	Addr     ReattachConfigAddr
+	Protocol        string
+	ProtocolVersion int
+	Pid             int
+	Test            bool
+	Addr            ReattachConfigAddr
 }
 
 // ReattachConfigAddr is a JSON-encoding friendly version of net.Addr.


### PR DESCRIPTION
As of go-plugin v1.4.1, the reattach config now contains protocol version information so that protocol version can be negotiated during reattach. Please see https://github.com/hashicorp/go-plugin/pull/171.