### PR TITLE
fix: find "terraform" command if execPath is empty in NewTerraform

### DIFF
--- a/tfexec/terraform.go
+++ b/tfexec/terraform.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"os/exec"
 	"sync"
 
 	"github.com/hashicorp/go-version"
@@ -71,10 +72,13 @@ func NewTerraform(workingDir string, execPath string) (*Terraform, error) {
 	}
 
 	if execPath == "" {
-		err := fmt.Errorf("NewTerraform: please supply the path to a Terraform executable using execPath, e.g. using the tfinstall package.")
-		return nil, &ErrNoSuitableBinary{
-			err: err,
+		p, err := exec.LookPath("terraform")
+		if err != nil {
+			return nil, &ErrNoSuitableBinary{
+				err: fmt.Errorf("NewTerraform: please supply the path to a Terraform executable using execPath, e.g. using the tfinstall package."),
+			}
 		}
+		execPath = p
 	}
 	tf := Terraform{
 		execPath:   execPath,


### PR DESCRIPTION
#188 

This pull request changes NewTerraform to find `terraform` command by exec.LookPath if execPath is empty.