### PR TITLE
tfexec: Improve error message for incompatible version

### DIFF
--- a/tfexec/exit_errors.go
+++ b/tfexec/exit_errors.go
@@ -243,5 +243,16 @@ type ErrTFVersionMismatch struct {
 }
 
 func (e *ErrTFVersionMismatch) Error() string {
-	return "terraform core version not supported by configuration"
+	version := "version"
+	if e.TFVersion != "" {
+		version = e.TFVersion
+	}
+
+	requirement := ""
+	if e.Constraint != "" {
+		requirement = fmt.Sprintf(" (%s required)", e.Constraint)
+	}
+
+	return fmt.Sprintf("terraform %s not supported by configuration%s",
+		version, requirement)
 }


### PR DESCRIPTION
I saw this error recently in LS CI

```
error: terraform core version not supported by configuration
```

and I think that we can make it more helpful this way.

## Example of new error format

```
error: terraform 1.1.0-dev not supported by configuration (~> 0.13 required)
```