### PR TITLE
Fix Terraform version assumptions in test data

### DIFF
--- a/tfexec/internal/e2etest/show_test.go
+++ b/tfexec/internal/e2etest/show_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 var (
-	v1_1_0 = version.Must(version.NewVersion("1.1.0"))
+	v1_0_1 = version.Must(version.NewVersion("1.0.1"))
 )
 
 func TestShow(t *testing.T) {
@@ -36,7 +36,7 @@ func TestShow(t *testing.T) {
 
 		formatVersion := "0.1"
 		var sensitiveValues json.RawMessage
-		if tfv.Core().GreaterThanOrEqual(v1_1_0) {
+		if tfv.Core().GreaterThanOrEqual(v1_0_1) {
 			formatVersion = "0.2"
 			sensitiveValues = json.RawMessage([]byte("{}"))
 		}
@@ -537,7 +537,7 @@ func TestShowBigInt(t *testing.T) {
 
 		formatVersion := "0.1"
 		var sensitiveValues json.RawMessage
-		if tfv.Core().GreaterThanOrEqual(v1_1_0) {
+		if tfv.Core().GreaterThanOrEqual(v1_0_1) {
 			formatVersion = "0.2"
 			sensitiveValues = json.RawMessage([]byte("{}"))
 		}

--- a/tfexec/internal/e2etest/state_mv_test.go
+++ b/tfexec/internal/e2etest/state_mv_test.go
@@ -31,7 +31,7 @@ func TestStateMv(t *testing.T) {
 
 		formatVersion := "0.1"
 		var sensitiveValues json.RawMessage
-		if tfv.Core().GreaterThanOrEqual(v1_1_0) {
+		if tfv.Core().GreaterThanOrEqual(v1_0_1) {
 			formatVersion = "0.2"
 			sensitiveValues = json.RawMessage([]byte("{}"))
 		}

--- a/tfexec/internal/e2etest/state_rm_test.go
+++ b/tfexec/internal/e2etest/state_rm_test.go
@@ -27,7 +27,7 @@ func TestStateRm(t *testing.T) {
 		}
 
 		formatVersion := "0.1"
-		if tfv.Core().GreaterThanOrEqual(v1_1_0) {
+		if tfv.Core().GreaterThanOrEqual(v1_0_1) {
 			formatVersion = "0.2"
 		}
 


### PR DESCRIPTION
This is to reflect that JSON output changes are already shipped in `1.0.1`:
https://github.com/hashicorp/terraform/releases/tag/v1.0.1
