### PR TITLE
Add StateShow

### DIFF
--- a/tfexec/internal/e2etest/state_show_test.go
+++ b/tfexec/internal/e2etest/state_show_test.go
@@ -1,0 +1,63 @@
+package e2etest
+
+import (
+	"context"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform-exec/tfexec"
+)
+
+func TestStateShow(t *testing.T) {
+	runTest(t, "basic_with_state", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+		if tfv.LessThan(providerAddressMinVersion) {
+			t.Skip("state file provider FQNs not compatible with this Terraform version")
+		}
+
+		err := tf.Init(context.Background())
+		if err != nil {
+			t.Fatalf("error running Init in test directory: %s", err)
+		}
+
+		resources := []struct {
+			address               string
+			expectedOutputPattern string
+			expectedErr           bool
+		}{
+			{
+				"null_resource.foo",
+				"^# null_resource\\.foo:\nresource \"null_resource\" \"foo\" {",
+				false,
+			},
+			{
+				"null_resource.bar",
+				// failure results in empty output
+				"^$",
+				true,
+			},
+		}
+
+		for _, resource := range resources {
+			gotOutput, err := tf.StateShow(context.Background(), resource.address)
+			gotErr := err != nil
+
+			if gotErr && !resource.expectedErr {
+				t.Fatalf("unexpected error running StateShow: %s", err)
+			}
+
+			if gotErr != resource.expectedErr {
+				t.Errorf("terraform state show %s error: %s", resource.address, err)
+			}
+
+			expectedRegexp, err := regexp.Compile(resource.expectedOutputPattern)
+			if err != nil {
+				t.Fatalf("unable to compile regexp: %s", err)
+			}
+
+			if !expectedRegexp.Match([]byte(gotOutput)) {
+				t.Errorf("terraform state show %s = %s", resource.address, gotOutput)
+			}
+		}
+	})
+}

--- a/tfexec/state_mv.go
+++ b/tfexec/state_mv.go
@@ -21,7 +21,7 @@ var defaultStateMvOptions = stateMvConfig{
 	lockTimeout: "0s",
 }
 
-// StateMvCmdOption represents options used in the Refresh method.
+// StateMvCmdOption represents options used in the StateMv method.
 type StateMvCmdOption interface {
 	configureStateMv(*stateMvConfig)
 }

--- a/tfexec/state_show.go
+++ b/tfexec/state_show.go
@@ -1,0 +1,58 @@
+package tfexec
+
+import (
+	"bytes"
+	"context"
+	"os/exec"
+)
+
+type stateShowConfig struct {
+	state string
+}
+
+var defaultStateShowOptions = stateShowConfig{}
+
+// StateShowCmdOption represents options used in the StateShow method.
+type StateShowCmdOption interface {
+	configureStateShow(*stateShowConfig)
+}
+
+func (opt *StateOption) configureStateShow(conf *stateShowConfig) {
+	conf.state = opt.path
+}
+
+// StateShow represents the terraform state show subcommand.
+func (tf *Terraform) StateShow(ctx context.Context, address string, opts ...StateShowCmdOption) (string, error) {
+	cmd, err := tf.stateShowCmd(ctx, address, opts...)
+	if err != nil {
+		return "", err
+	}
+
+	var outBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+
+	err = tf.runTerraformCmd(ctx, cmd)
+	if err != nil {
+		return "", err
+	}
+
+	return outBuf.String(), nil
+}
+
+func (tf *Terraform) stateShowCmd(ctx context.Context, address string, opts ...StateShowCmdOption) (*exec.Cmd, error) {
+	c := stateShowConfig{}
+
+	for _, o := range opts {
+		o.configureStateShow(&c)
+	}
+
+	args := []string{"state", "show", "-no-color"}
+
+	// string opts: only pass if set
+	if c.state != "" {
+		args = append(args, "-state="+c.state)
+	}
+	args = append(args, address)
+
+	return tf.buildTerraformCmd(ctx, nil, args...), nil
+}

--- a/tfexec/state_show_test.go
+++ b/tfexec/state_show_test.go
@@ -1,0 +1,49 @@
+package tfexec
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-exec/tfexec/internal/testutil"
+)
+
+func TestStateShowCmd(t *testing.T) {
+	td := testTempDir(t)
+
+	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest013))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// empty env, to avoid environ mismatch in testing
+	tf.SetEnv(map[string]string{})
+
+	t.Run("defaults", func(t *testing.T) {
+		stateShowCmd, err := tf.stateShowCmd(context.Background(), "testaddress")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assertCmd(t, []string{
+			"state",
+			"show",
+			"-no-color",
+			"testaddress",
+		}, nil, stateShowCmd)
+	})
+
+	t.Run("override all defaults", func(t *testing.T) {
+		stateShowCmd, err := tf.stateShowCmd(context.Background(), "testaddress", State("teststate"))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assertCmd(t, []string{
+			"state",
+			"show",
+			"-no-color",
+			"-state=teststate",
+			"testaddress",
+		}, nil, stateShowCmd)
+	})
+}


### PR DESCRIPTION
Included in this PR is the addition of the `StateShow` method.

This method returns the stdout of the executed `terraform` command, or an error if encountered.