### PR TITLE
refactor: Replace `bytes.Buffer` with `strings.Builder`

### DIFF
--- a/tfexec/fmt.go
+++ b/tfexec/fmt.go
@@ -1,7 +1,6 @@
 package tfexec
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -44,7 +43,7 @@ func FormatString(ctx context.Context, execPath string, content string) (string,
 // FormatString formats a passed string.
 func (tf *Terraform) FormatString(ctx context.Context, content string) (string, error) {
 	in := strings.NewReader(content)
-	var outBuf bytes.Buffer
+	var outBuf strings.Builder
 	err := tf.Format(ctx, in, &outBuf)
 	if err != nil {
 		return "", err
@@ -101,7 +100,7 @@ func (tf *Terraform) FormatCheck(ctx context.Context, opts ...FormatOption) (boo
 		return false, nil, err
 	}
 
-	var outBuf bytes.Buffer
+	var outBuf strings.Builder
 	cmd.Stdout = mergeWriters(cmd.Stdout, &outBuf)
 
 	err = tf.runTerraformCmd(ctx, cmd)

--- a/tfexec/internal/e2etest/fmt_test.go
+++ b/tfexec/internal/e2etest/fmt_test.go
@@ -1,7 +1,6 @@
 package e2etest
 
 import (
-	"bytes"
 	"context"
 	"io"
 	"io/ioutil"
@@ -106,7 +105,7 @@ resource "foo" "bar" {
 `)
 
 		start := time.Now()
-		var actual bytes.Buffer
+		var actual strings.Builder
 		err := tf.Format(context.Background(), strings.NewReader(unformatted), &actual)
 		if err != nil {
 			t.Fatal(err)

--- a/tfexec/show.go
+++ b/tfexec/show.go
@@ -1,10 +1,10 @@
 package tfexec
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"os/exec"
+	"strings"
 
 	tfjson "github.com/hashicorp/terraform-json"
 )
@@ -173,14 +173,14 @@ func (tf *Terraform) ShowPlanFileRaw(ctx context.Context, planPath string, opts 
 
 	showCmd := tf.showCmd(ctx, false, mergeEnv, planPath)
 
-	var ret bytes.Buffer
-	showCmd.Stdout = &ret
+	var outBuf strings.Builder
+	showCmd.Stdout = &outBuf
 	err := tf.runTerraformCmd(ctx, showCmd)
 	if err != nil {
 		return "", err
 	}
 
-	return ret.String(), nil
+	return outBuf.String(), nil
 
 }
 

--- a/tfexec/validate.go
+++ b/tfexec/validate.go
@@ -19,8 +19,8 @@ func (tf *Terraform) Validate(ctx context.Context) (*tfjson.ValidateOutput, erro
 
 	cmd := tf.buildTerraformCmd(ctx, nil, "validate", "-no-color", "-json")
 
-	var outbuf = bytes.Buffer{}
-	cmd.Stdout = &outbuf
+	var outBuf = bytes.Buffer{}
+	cmd.Stdout = &outBuf
 
 	err = tf.runTerraformCmd(ctx, cmd)
 	// TODO: this command should not exit 1 if you pass -json as its hard to differentiate other errors
@@ -30,7 +30,7 @@ func (tf *Terraform) Validate(ctx context.Context) (*tfjson.ValidateOutput, erro
 
 	var ret tfjson.ValidateOutput
 	// TODO: ret.UseJSONNumber(true) validate output should support JSON numbers
-	jsonErr := json.Unmarshal(outbuf.Bytes(), &ret)
+	jsonErr := json.Unmarshal(outBuf.Bytes(), &ret)
 	if jsonErr != nil {
 		// the original call was possibly bad, if it has an error, actually just return that
 		if err != nil {

--- a/tfexec/version.go
+++ b/tfexec/version.go
@@ -89,7 +89,7 @@ func parseJsonVersionOutput(stdout []byte) (*version.Version, map[string]*versio
 func (tf *Terraform) versionFromPlaintext(ctx context.Context) (*version.Version, map[string]*version.Version, error) {
 	versionCmd := tf.buildTerraformCmd(ctx, nil, "version")
 
-	var outBuf bytes.Buffer
+	var outBuf strings.Builder
 	versionCmd.Stdout = &outBuf
 
 	err := tf.runTerraformCmd(ctx, versionCmd)

--- a/tfexec/workspace_list.go
+++ b/tfexec/workspace_list.go
@@ -1,7 +1,6 @@
 package tfexec
 
 import (
-	"bytes"
 	"context"
 	"strings"
 )
@@ -11,7 +10,7 @@ func (tf *Terraform) WorkspaceList(ctx context.Context) ([]string, string, error
 	// TODO: [DIR] param option
 	wlCmd := tf.buildTerraformCmd(ctx, nil, "workspace", "list", "-no-color")
 
-	var outBuf bytes.Buffer
+	var outBuf strings.Builder
 	wlCmd.Stdout = &outBuf
 
 	err := tf.runTerraformCmd(ctx, wlCmd)


### PR DESCRIPTION
This is a minor refactoring as a follow-up to a recently merged PR #209 