### PR TITLE
tfexec: Add support for Plan/Apply `Replace` option

### DIFF
--- a/tfexec/apply_test.go
+++ b/tfexec/apply_test.go
@@ -10,7 +10,7 @@ import (
 func TestApplyCmd(t *testing.T) {
 	td := testTempDir(t)
 
-	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest012))
+	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest_v1))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -29,6 +29,8 @@ func TestApplyCmd(t *testing.T) {
 			Lock(false),
 			Parallelism(99),
 			Refresh(false),
+			Replace("aws_instance.test"),
+			Replace("google_pubsub_topic.test"),
 			Target("target1"),
 			Target("target2"),
 			Var("var1=foo"),
@@ -53,6 +55,8 @@ func TestApplyCmd(t *testing.T) {
 			"-lock=false",
 			"-parallelism=99",
 			"-refresh=false",
+			"-replace=aws_instance.test",
+			"-replace=google_pubsub_topic.test",
 			"-target=target1",
 			"-target=target2",
 			"-var", "var1=foo",

--- a/tfexec/options.go
+++ b/tfexec/options.go
@@ -296,6 +296,14 @@ func Refresh(refresh bool) *RefreshOption {
 	return &RefreshOption{refresh}
 }
 
+type ReplaceOption struct {
+	address string
+}
+
+func Replace(address string) *ReplaceOption {
+	return &ReplaceOption{address}
+}
+
 type StateOption struct {
 	path string
 }

--- a/tfexec/plan_test.go
+++ b/tfexec/plan_test.go
@@ -10,7 +10,7 @@ import (
 func TestPlanCmd(t *testing.T) {
 	td := testTempDir(t)
 
-	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest012))
+	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest_v1))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -37,7 +37,22 @@ func TestPlanCmd(t *testing.T) {
 	})
 
 	t.Run("override all defaults", func(t *testing.T) {
-		planCmd, err := tf.planCmd(context.Background(), Destroy(true), Lock(false), LockTimeout("22s"), Out("whale"), Parallelism(42), Refresh(false), State("marvin"), Target("zaphod"), Target("beeblebrox"), Var("android=paranoid"), Var("brain_size=planet"), VarFile("trillian"), Dir("earth"))
+		planCmd, err := tf.planCmd(context.Background(),
+			Destroy(true),
+			Lock(false),
+			LockTimeout("22s"),
+			Out("whale"),
+			Parallelism(42),
+			Refresh(false),
+			Replace("ford.prefect"),
+			Replace("arthur.dent"),
+			State("marvin"),
+			Target("zaphod"),
+			Target("beeblebrox"),
+			Var("android=paranoid"),
+			Var("brain_size=planet"),
+			VarFile("trillian"),
+			Dir("earth"))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -54,6 +69,8 @@ func TestPlanCmd(t *testing.T) {
 			"-lock=false",
 			"-parallelism=42",
 			"-refresh=false",
+			"-replace=ford.prefect",
+			"-replace=arthur.dent",
 			"-destroy",
 			"-target=zaphod",
 			"-target=beeblebrox",

--- a/tfexec/version.go
+++ b/tfexec/version.go
@@ -19,6 +19,7 @@ var (
 	tf0_13_0 = version.Must(version.NewVersion("0.13.0"))
 	tf0_14_0 = version.Must(version.NewVersion("0.14.0"))
 	tf0_15_0 = version.Must(version.NewVersion("0.15.0"))
+	tf0_15_2 = version.Must(version.NewVersion("0.15.2"))
 	tf1_1_0  = version.Must(version.NewVersion("1.1.0"))
 )
 


### PR DESCRIPTION
Closes #184 

https://www.terraform.io/docs/cli/commands/plan.html#replace-address

> The `-replace=...` option is available only from Terraform v0.15.2 onwards. For earlier versions, you can achieve a similar effect (with some caveats) using `terraform taint`.

