### PR TITLE
Fix Windows CI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,8 +8,6 @@ commands:
   win_install_go:
     steps:
       - run:
-          command: choco install golang --version 1.16.4 --yes
-      - run:
           command: go version
   macos_install_go:
     steps:


### PR DESCRIPTION
`winbuildtest` has been failing since 14th September with:

```
#!powershell.exe -ExecutionPolicy Bypass
choco install golang --version 1.16.4 --yes
Chocolatey v0.11.1
Installing the following packages:
golang
By installing, you accept licenses for the packages.
A newer version of golang (v1.17) is already installed.
 Use --allow-downgrade or --force to attempt to install older versions, or use --side-by-side to allow multiple versions.

Chocolatey installed 0/1 packages. 1 packages failed.
 See the log for details (C:\ProgramData\chocolatey\logs\chocolatey.log).

Failures
 - golang - A newer version of golang (v1.17) is already installed.
 Use --allow-downgrade or --force to attempt to install older versions, or use --side-by-side to allow multiple versions.

Exited with code exit status 1
CircleCI received exit code 1
```

It looks like Golang 1.17 is already installed on the runner, so our build step is unnecessary.