### PR TITLE
add error wrapping for locked state

### DIFF
--- a/tfexec/cmdstring.go
+++ b/tfexec/cmdstring.go
@@ -1,4 +1,4 @@
-// +build go1.13
+//go:build go1.13
 
 package tfexec
 

--- a/tfexec/cmdstring.go
+++ b/tfexec/cmdstring.go
@@ -1,4 +1,4 @@
-//go:build go1.13
+// +build go1.13
 
 package tfexec
 

--- a/tfexec/exit_errors.go
+++ b/tfexec/exit_errors.go
@@ -1,7 +1,6 @@
 package tfexec
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"os/exec"
@@ -300,7 +299,7 @@ func (e *ErrStateLocked) Error() string {
 `
 
 	t := template.Must(template.New("LockInfo").Parse(tmpl))
-	var out bytes.Buffer
+	var out strings.Builder
 	if err := t.Execute(&out, e); err != nil {
 		return "error acquiring the state lock"
 	}

--- a/tfexec/exit_errors.go
+++ b/tfexec/exit_errors.go
@@ -1,11 +1,13 @@
 package tfexec
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os/exec"
 	"regexp"
 	"strings"
+	"text/template"
 )
 
 // this file contains errors parsed from stderr
@@ -30,6 +32,9 @@ var (
 	tfVersionMismatchErrRegexp        = regexp.MustCompile(`Error: The currently running version of Terraform doesn't meet the|Error: Unsupported Terraform Core version`)
 	tfVersionMismatchConstraintRegexp = regexp.MustCompile(`required_version = "(.+)"|Required version: (.+)\b`)
 	configInvalidErrRegexp            = regexp.MustCompile(`There are some problems with the configuration, described below.`)
+
+	stateLockErrRegexp  = regexp.MustCompile(`Error acquiring the state lock`)
+	stateLockInfoRegexp = regexp.MustCompile(`Lock Info:\nID:\s*(.*)\nPath:\s*(.*)\nOperation:\s*(.*)\nWho:\s*(.*)\nVersion:\s*(.*)\nCreated:\s*(.*)\n`)
 )
 
 func (tf *Terraform) wrapExitError(ctx context.Context, err error, stderr string) error {
@@ -128,6 +133,20 @@ func (tf *Terraform) wrapExitError(ctx context.Context, err error, stderr string
 		}
 	case configInvalidErrRegexp.MatchString(stderr):
 		return &ErrConfigInvalid{stderr: stderr}
+	case stateLockErrRegexp.MatchString(stderr):
+		submatches := stateLockInfoRegexp.FindStringSubmatch(stderr)
+		if len(submatches) == 7 {
+			return &ErrStateLocked{
+				unwrapper: unwrapper{exitErr, ctxErr},
+
+				ID:        submatches[1],
+				Path:      submatches[2],
+				Operation: submatches[3],
+				Who:       submatches[4],
+				Version:   submatches[5],
+				Created:   submatches[6],
+			}
+		}
 	}
 
 	return fmt.Errorf("%w\n%s", &unwrapper{exitErr, ctxErr}, stderr)
@@ -256,4 +275,34 @@ func (e *ErrTFVersionMismatch) Error() string {
 
 	return fmt.Sprintf("terraform %s not supported by configuration%s",
 		version, requirement)
+}
+
+// ErrStateLocked is returned when the state lock is already held by another process.
+type ErrStateLocked struct {
+	unwrapper
+
+	ID        string
+	Path      string
+	Operation string
+	Who       string
+	Version   string
+	Created   string
+}
+
+func (e *ErrStateLocked) Error() string {
+	tmpl := `Lock Info:
+  ID:        {{.ID}}
+  Path:      {{.Path}}
+  Operation: {{.Operation}}
+  Who:       {{.Who}}
+  Version:   {{.Version}}
+  Created:   {{.Created}}
+`
+
+	t := template.Must(template.New("LockInfo").Parse(tmpl))
+	var out bytes.Buffer
+	if err := t.Execute(&out, e); err != nil {
+		return "error acquiring the state lock"
+	}
+	return fmt.Sprintf("error acquiring the state lock: %v", out.String())
 }

--- a/tfexec/exit_errors.go
+++ b/tfexec/exit_errors.go
@@ -33,7 +33,7 @@ var (
 	configInvalidErrRegexp            = regexp.MustCompile(`There are some problems with the configuration, described below.`)
 
 	stateLockErrRegexp  = regexp.MustCompile(`Error acquiring the state lock`)
-	stateLockInfoRegexp = regexp.MustCompile(`Lock Info:\n\s*ID:\s*(.*)\n\s*Path:\s*(.*)\n\s*Operation:\s*(.*)\n\s*Who:\s*(.*)\n\s*Version:\s*(.*)\n\s*Created:\s*(.*)\n`)
+	stateLockInfoRegexp = regexp.MustCompile(`Lock Info:\n\s*ID:\s*([^\n]+)\n\s*Path:\s*([^\n]+)\n\s*Operation:\s*([^\n]+)\n\s*Who:\s*([^\n]+)\n\s*Version:\s*([^\n]+)\n\s*Created:\s*([^\n]+)\n`)
 )
 
 func (tf *Terraform) wrapExitError(ctx context.Context, err error, stderr string) error {

--- a/tfexec/internal/e2etest/errors_test.go
+++ b/tfexec/internal/e2etest/errors_test.go
@@ -1,5 +1,5 @@
 // This file contains tests that only compile/work in Go 1.13 and forward
-// +build go1.13
+//go:build go1.13
 
 package e2etest
 
@@ -123,6 +123,25 @@ func TestTFVersionMismatch(t *testing.T) {
 		var ee *exec.ExitError
 		if !errors.As(err, &ee) {
 			t.Fatalf("expected exec.ExitError, got %T, %s", err, err)
+		}
+	})
+}
+
+func TestLockedState(t *testing.T) {
+	runTest(t, "inmem-backend-locked", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+		err := tf.Init(context.Background())
+		if err != nil {
+			t.Fatalf("err during init: %s", err)
+		}
+
+		err = tf.Apply(context.Background())
+		if err == nil {
+			t.Fatal("expected error, but didn't find one")
+		}
+
+		var stateLockedErr *tfexec.ErrStateLocked
+		if !errors.As(err, &stateLockedErr) {
+			t.Fatalf("expected ErrTFVersionMismatch, got %T, %s", err, err)
 		}
 	})
 }

--- a/tfexec/internal/e2etest/errors_test.go
+++ b/tfexec/internal/e2etest/errors_test.go
@@ -1,5 +1,5 @@
 // This file contains tests that only compile/work in Go 1.13 and forward
-//go:build go1.13
+// +build go1.13
 
 package e2etest
 

--- a/tfexec/internal/e2etest/testdata/inmem-backend-locked/main.tf
+++ b/tfexec/internal/e2etest/testdata/inmem-backend-locked/main.tf
@@ -1,0 +1,5 @@
+terraform {
+	backend "inmem" {
+		lock_id = "2b6a6738-5dd5-50d6-c0ae-f6352977666b"
+	}
+}


### PR DESCRIPTION
Adds parsing for errors where Terraform fails to acquire a state lock. Returns a first-class `ErrStateLocked` error, including the corresponding `LockInfo`.  

Uses a slightly different [LockInfo structure](https://github.com/hashicorp/terraform/blob/a742d7ee8820f84afb1f0a3ec946b35ee5b26f84/internal/states/statemgr/locker.go#L187-L194) from upstream Terraform: 
* Excludes the `Info` section simply out of difficulty parsing out where that blurb ends
* Treats `Created` as a string instead of date, mostly because I wasn't sure how to handle the (unlikely) error from `time.Parse()` in `wrapExitError()`

_Side note:_ I don't see as much of a use-case for an `Unlock()` error, but I'm happy to add that in as well.

I've created a mini test-case here: https://play.golang.org/p/aAeRS5yOb7x. I can add some test cases for `exit_errors.go` if that's preferred though.

(Related to https://github.com/hashicorp/terraform-exec/issues/222)