### PR TITLE
deps: Bump terraform-json to 0.13.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/hashicorp/go-getter v1.5.3
 	github.com/hashicorp/go-version v1.3.0
 	github.com/hashicorp/logutils v1.0.0
-	github.com/hashicorp/terraform-json v0.12.0
+	github.com/hashicorp/terraform-json v0.13.0
 	github.com/mitchellh/cli v1.1.2
 	github.com/sergi/go-diff v1.2.0
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -111,8 +111,8 @@ github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
-github.com/hashicorp/terraform-json v0.12.0 h1:8czPgEEWWPROStjkWPUnTQDXmpmZPlkQAwYYLETaTvw=
-github.com/hashicorp/terraform-json v0.12.0/go.mod h1:pmbq9o4EuL43db5+0ogX10Yofv1nozM+wskr/bGFJpI=
+github.com/hashicorp/terraform-json v0.13.0 h1:Li9L+lKD1FO5RVFRM1mMMIBDoUHslOniyEi5CM+FWGY=
+github.com/hashicorp/terraform-json v0.13.0/go.mod h1:y5OdLBCT+rxbwnpxZs9kGL7R9ExU76+cpdY8zHwoazk=
 github.com/huandu/xstrings v1.3.2 h1:L18LIDzqlW6xN2rEkpdV8+oL/IXWJ1APd+vsdYy4Wdw=
 github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
@@ -187,7 +187,6 @@ github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgq
 github.com/xanzy/ssh-agent v0.3.0 h1:wUMzuKtKilRgBAD1sUb8gOwwRr2FGoBVumcjoOACClI=
 github.com/xanzy/ssh-agent v0.3.0/go.mod h1:3s9xbODqPuuhK9JV1R321M/FlMZSBvE5aY6eAcqrDh0=
 github.com/zclconf/go-cty v1.2.0/go.mod h1:hOPWgoHbaTUnI5k4D2ld+GRpFJSCe6bCM7m1q/N4PQ8=
-github.com/zclconf/go-cty v1.2.1/go.mod h1:hOPWgoHbaTUnI5k4D2ld+GRpFJSCe6bCM7m1q/N4PQ8=
 github.com/zclconf/go-cty v1.9.1 h1:viqrgQwFl5UpSxc046qblj78wZXVDFnSOufaOTER+cc=
 github.com/zclconf/go-cty v1.9.1/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=
 github.com/zclconf/go-cty-debug v0.0.0-20191215020915-b22d67c1ba0b h1:FosyBZYxY34Wul7O/MSKey3txpPYyCqVO5ZyceuQJEI=

--- a/tfexec/internal/e2etest/providers_schema_test.go
+++ b/tfexec/internal/e2etest/providers_schema_test.go
@@ -16,6 +16,7 @@ var (
 	providersSchemaJSONMinVersion = version.Must(version.NewVersion("0.12.0"))
 	v0_13_0                       = version.Must(version.NewVersion("0.13.0"))
 	v0_15_0                       = version.Must(version.NewVersion("0.15.0"))
+	v1_1                          = version.Must(version.NewVersion("1.1.0"))
 )
 
 func TestProvidersSchema(t *testing.T) {
@@ -27,6 +28,8 @@ func TestProvidersSchema(t *testing.T) {
 			"basic", func(tfv *version.Version) *tfjson.ProviderSchemas {
 				var providerSchema *tfjson.ProviderSchemas
 
+				// TODO: Add handling for v1 format once it lands in core
+				// See https://github.com/hashicorp/terraform/pull/29550
 				if tfv.Core().GreaterThanOrEqual(v0_15_0) {
 					providerSchema = &tfjson.ProviderSchemas{
 						FormatVersion: "0.2",
@@ -287,6 +290,9 @@ same can now be achieved using [locals](https://www.terraform.io/docs/language/v
 		},
 		{
 			"empty_with_tf_file", func(tfv *version.Version) *tfjson.ProviderSchemas {
+				// TODO: Add handling for v1 format once it lands in core
+				// See https://github.com/hashicorp/terraform/pull/29550
+
 				if tfv.Core().GreaterThanOrEqual(v0_15_0) {
 					return &tfjson.ProviderSchemas{
 						FormatVersion: "0.2",

--- a/tfexec/internal/e2etest/util_test.go
+++ b/tfexec/internal/e2etest/util_test.go
@@ -35,6 +35,7 @@ func runTest(t *testing.T, fixtureName string, cb func(t *testing.T, tfVersion *
 		testutil.Latest014,
 		testutil.Latest015,
 		testutil.Latest_v1,
+		testutil.Latest_v1_1,
 	}
 	if override := os.Getenv("TFEXEC_E2ETEST_VERSIONS"); override != "" {
 		versions = strings.Split(override, ",")

--- a/tfexec/internal/testutil/tfcache.go
+++ b/tfexec/internal/testutil/tfcache.go
@@ -15,7 +15,7 @@ const (
 	Latest014   = "0.14.11"
 	Latest015   = "0.15.5"
 	Latest_v1   = "1.0.0"
-	Latest_v1_1 = "1.1.0-alpha20210811"
+	Latest_v1_1 = "1.1.0-alpha20210922"
 )
 
 const appendUserAgent = "tfexec-testutil"


### PR DESCRIPTION
I wanted to add tests for the new v1 format, but the [relevant PR](https://github.com/hashicorp/terraform/pull/29550) was not merged yet, so I just left a TODO in the appropriate places and the existing tests should fail when we bump `Latest_v1_1` - so we can cross the bridge when we get to it.

cc @alisdair

--- 

This brings in a bug fix for a panic: https://github.com/hashicorp/terraform-json/pull/44 which is the main motivation for the bump here.

--- 

I have prepared a draft PR https://github.com/hashicorp/terraform-exec/pull/226 with the necessary changes accounting for JSON format changes in TF 1.1.