### PR TITLE
fix: Account for upcoming init error message change

### DIFF
--- a/tfexec/exit_errors.go
+++ b/tfexec/exit_errors.go
@@ -18,9 +18,10 @@ var (
 
 	usageRegexp = regexp.MustCompile(`Too many command line arguments|^Usage: .*Options:.*|Error: Invalid -\d+ option`)
 
-	// "Could not load plugin" is present in 0.13
-	// "Please run \"terraform init\"" is present in v1.1.0
-	noInitErrRegexp = regexp.MustCompile(`Error: Could not satisfy plugin requirements|Error: Could not load plugin|Please run \"terraform init\"`)
+	noInitErrRegexp = regexp.MustCompile(`Error: Could not satisfy plugin requirements|` +
+		`Error: Could not load plugin|` + // v0.13
+		`Please run \"terraform init\"|` + // v1.1.0 early alpha versions (ref 89b05050)
+		`run:\s+terraform init`) // v1.1.0 (ref df578afd)
 
 	noConfigErrRegexp = regexp.MustCompile(`Error: No configuration files`)
 


### PR DESCRIPTION
This is to address the following nightly test failure:

```
    util_test.go:113: [INFO] running Terraform command: /tmp/tfinstall756103370/gitref-refs-heads-main/terraform470134907 show -json -no-color
    show_test.go:90: expected error ErrNoInit, got *fmt.wrapError: exit status 1
        
        Error: Inconsistent dependency lock file
        
        The following dependency selections recorded in the lock file are
        inconsistent with the current configuration:
          - provider registry.terraform.io/hashicorp/null: required by this configuration but no version is selected
        
        To make the initial dependency selections that will initialize the dependency
        lock file, run:
          terraform init
        
--- FAIL: TestShow_errInitRequired (0.12s)
    --- FAIL: TestShow_errInitRequired/basic-refs/heads/main (0.12s)
```