### PR TITLE
tests: Fix missed testTempDir -> t.TempDir

### DIFF
--- a/tfexec/workspace_delete_test.go
+++ b/tfexec/workspace_delete_test.go
@@ -8,9 +8,7 @@ import (
 )
 
 func TestWorkspaceDeleteCmd(t *testing.T) {
-	td := testTempDir(t)
-
-	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest013))
+	tf, err := NewTerraform(t.TempDir(), tfVersion(t, testutil.Latest013))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
The replacement and removal of `testTempDir` was done in https://github.com/hashicorp/terraform-exec/commit/eccad43b4c2e218b66878810bfbe89b8b117d392 (as part of https://github.com/hashicorp/terraform-exec/pull/216) but it was merged around the same time as https://github.com/hashicorp/terraform-exec/pull/212 which still had a reference to that removed function.