### PR TITLE
tests: bump to 1.0.10 and 1.1.0-beta1

### DIFF
--- a/tfexec/internal/testutil/tfcache.go
+++ b/tfexec/internal/testutil/tfcache.go
@@ -17,8 +17,8 @@ const (
 	Latest013   = "0.13.7"
 	Latest014   = "0.14.11"
 	Latest015   = "0.15.5"
-	Latest_v1   = "1.0.0"
-	Latest_v1_1 = "1.1.0-alpha20211006"
+	Latest_v1   = "1.0.10"
+	Latest_v1_1 = "1.1.0-beta1"
 )
 
 const appendUserAgent = "tfexec-testutil"


### PR DESCRIPTION
Latest v1 is now v1.0.10, and latest v1.1.0 is v1.1.0-beta1.