### PR TITLE
Add support for the `workspace show` command

### DIFF
--- a/tfexec/version.go
+++ b/tfexec/version.go
@@ -15,6 +15,7 @@ import (
 
 var (
 	tf0_7_7  = version.Must(version.NewVersion("0.7.7"))
+	tf0_10_0 = version.Must(version.NewVersion("0.10.0"))
 	tf0_12_0 = version.Must(version.NewVersion("0.12.0"))
 	tf0_13_0 = version.Must(version.NewVersion("0.13.0"))
 	tf0_14_0 = version.Must(version.NewVersion("0.14.0"))

--- a/tfexec/workspace_show.go
+++ b/tfexec/workspace_show.go
@@ -1,0 +1,21 @@
+package tfexec
+
+import (
+	"context"
+	"strings"
+)
+
+// WorkspaceShow represents the workspace show subcommand to the Terraform CLI.
+func (tf *Terraform) WorkspaceShow(ctx context.Context) (string, error) {
+	workspaceShowCmd := tf.buildTerraformCmd(ctx, nil, "workspace", "show", "-no-color")
+
+	var outBuffer strings.Builder
+	workspaceShowCmd.Stdout = &outBuffer
+
+	err := tf.runTerraformCmd(ctx, workspaceShowCmd)
+	if err != nil {
+		return "", err
+	}
+
+	return strings.TrimSpace(outBuffer.String()), nil
+}

--- a/tfexec/workspace_show.go
+++ b/tfexec/workspace_show.go
@@ -2,20 +2,34 @@ package tfexec
 
 import (
 	"context"
+	"fmt"
+	"os/exec"
 	"strings"
 )
 
 // WorkspaceShow represents the workspace show subcommand to the Terraform CLI.
 func (tf *Terraform) WorkspaceShow(ctx context.Context) (string, error) {
-	workspaceShowCmd := tf.buildTerraformCmd(ctx, nil, "workspace", "show", "-no-color")
+	workspaceShowCmd, err := tf.workspaceShowCmd(ctx)
+	if err != nil {
+		return "", err
+	}
 
 	var outBuffer strings.Builder
 	workspaceShowCmd.Stdout = &outBuffer
 
-	err := tf.runTerraformCmd(ctx, workspaceShowCmd)
+	err = tf.runTerraformCmd(ctx, workspaceShowCmd)
 	if err != nil {
 		return "", err
 	}
 
 	return strings.TrimSpace(outBuffer.String()), nil
+}
+
+func (tf *Terraform) workspaceShowCmd(ctx context.Context) (*exec.Cmd, error) {
+	err := tf.compatible(ctx, tf0_10_0, nil)
+	if err != nil {
+		return nil, fmt.Errorf("workspace show was first introduced in Terraform 0.10.0: %w", err)
+	}
+
+	return tf.buildTerraformCmd(ctx, nil, "workspace", "show", "-no-color"), nil
 }

--- a/tfexec/workspace_show_test.go
+++ b/tfexec/workspace_show_test.go
@@ -1,0 +1,31 @@
+package tfexec
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestWorkspaceShowCmd(t *testing.T) {
+	td := t.TempDir()
+
+	tf, err := NewTerraform(td, tfVersion(t, "0.9.11"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// empty env, to avoid environ mismatch in testing
+	tf.SetEnv(map[string]string{})
+
+	t.Run("too old version", func(t *testing.T) {
+		_, err := tf.workspaceShowCmd(context.Background())
+		if err == nil {
+			t.Fatal("expected old version to fail")
+		}
+
+		var expectedErr *ErrVersionMismatch
+		if !errors.As(err, &expectedErr) {
+			t.Fatalf("error doesn't match: %#v", err)
+		}
+	})
+}


### PR DESCRIPTION
## Description

This PR adds support for the `workspace show` command. 

Closes #239 

## Related links

- [workspace show documentation](https://www.terraform.io/docs/cli/commands/workspace/show.html)