### PR TITLE
circleci: bump timeout for E2E tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,8 +30,8 @@ commands:
   go_e2e_test:
     steps:
       - run:
-          no_output_timeout: 15m
-          command: go test -timeout=15m -v ./tfexec/internal/e2etest
+          no_output_timeout: 20m
+          command: go test -timeout=20m -v ./tfexec/internal/e2etest
 
 jobs:
   # combined due to slowness of Go install


### PR DESCRIPTION
We had E2E tests time out on `main` and in PRs recently:

https://app.circleci.com/pipelines/github/hashicorp/terraform-exec/1334/workflows/d059b80e-43e4-4ea8-905f-165efaec939f/jobs/16081
https://app.circleci.com/pipelines/github/hashicorp/terraform-exec/1327/workflows/671e306a-746c-47d7-a14e-490b09c768e4/jobs/16037

Even when tests pass they get very close to the timeout, so this change aims to reduce the chance of the job timing out.
