### PR TITLE
Fixed go routine leak

### DIFF
--- a/tfexec/cmd_linux.go
+++ b/tfexec/cmd_linux.go
@@ -8,6 +8,9 @@ import (
 )
 
 func (tf *Terraform) runTerraformCmd(ctx context.Context, cmd *exec.Cmd) error {
+	ctx, done := context.WithCancel(ctx)
+	defer done() 
+	
 	var errBuf strings.Builder
 
 	cmd.Stdout = mergeWriters(cmd.Stdout, tf.stdout)


### PR DESCRIPTION
In `runTerraformCmd` if the context is never terminated, the created goroutine would never complete, nor be garbage collected, thus leading to goroutine leak.
