### PR TITLE
Implements the graph command

### DIFF
--- a/tfexec/graph.go
+++ b/tfexec/graph.go
@@ -1,0 +1,81 @@
+package tfexec
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+type graphConfig struct {
+	plan        string
+	drawCycles  bool
+	graphType   string
+	moduleDepth int
+}
+
+var defaultGraphOptions = graphConfig{
+	moduleDepth: -1,
+}
+
+type GraphOption interface {
+	configureGraph(*graphConfig)
+}
+
+func (opt *GraphPlanOption) configureGraph(conf *graphConfig) {
+	conf.plan = opt.file
+}
+
+func (opt *DrawCyclesOption) configureGraph(conf *graphConfig) {
+	conf.drawCycles = opt.drawCycles
+}
+
+func (opt *GraphTypeOption) configureGraph(conf *graphConfig) {
+	conf.graphType = opt.graphType
+}
+
+func (opt *ModuleDepthOption) configureGraph(conf *graphConfig) {
+	conf.moduleDepth = opt.moduleDepth
+}
+
+func (tf *Terraform) Graph(ctx context.Context, opts ...GraphOption) (string, error) {
+	graphCmd := tf.graphCmd(ctx, opts...)
+	var outBuf strings.Builder
+	graphCmd.Stdout = &outBuf
+	err := tf.runTerraformCmd(ctx, graphCmd)
+	if err != nil {
+		return "", err
+	}
+
+	return outBuf.String(), nil
+
+}
+
+func (tf *Terraform) graphCmd(ctx context.Context, opts ...GraphOption) *exec.Cmd {
+	c := defaultGraphOptions
+
+	for _, o := range opts {
+		o.configureGraph(&c)
+	}
+
+	args := []string{"graph"}
+
+	if c.plan != "" {
+		args = append(args, "-plan="+c.plan)
+	}
+
+	if c.drawCycles {
+		args = append(args, "-draw-cycles")
+	}
+
+	if c.graphType != "" {
+		args = append(args, "-type="+c.graphType)
+	}
+
+	// -1 is the default value set in terraform CLI for module depth
+	if c.moduleDepth != -1 {
+		args = append(args, fmt.Sprintf("-module-depth=%d", c.moduleDepth))
+	}
+
+	return tf.buildTerraformCmd(ctx, nil, args...)
+}

--- a/tfexec/graph_test.go
+++ b/tfexec/graph_test.go
@@ -1,0 +1,44 @@
+package tfexec
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-exec/tfexec/internal/testutil"
+)
+
+func TestGraphCmd(t *testing.T) {
+	td := t.TempDir()
+
+	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest013))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// empty env, to avoid environ mismatch in testing
+	tf.SetEnv(map[string]string{})
+
+	t.Run("defaults", func(t *testing.T) {
+		graphCmd := tf.graphCmd(context.Background())
+
+		assertCmd(t, []string{
+			"graph",
+		}, nil, graphCmd)
+	})
+
+	t.Run("override all defaults", func(t *testing.T) {
+		graphCmd := tf.graphCmd(context.Background(),
+			GraphPlan("teststate"),
+			DrawCycles(true),
+			GraphType("output"),
+			ModuleDepth(2))
+
+		assertCmd(t, []string{
+			"graph",
+			"-plan=teststate",
+			"-draw-cycles",
+			"-type=output",
+			"-module-depth=2",
+		}, nil, graphCmd)
+	})
+}

--- a/tfexec/graph_test.go
+++ b/tfexec/graph_test.go
@@ -19,7 +19,7 @@ func TestGraphCmd(t *testing.T) {
 	tf.SetEnv(map[string]string{})
 
 	t.Run("defaults", func(t *testing.T) {
-		graphCmd := tf.graphCmd(context.Background())
+		graphCmd, _ := tf.graphCmd(context.Background())
 
 		assertCmd(t, []string{
 			"graph",
@@ -27,18 +27,50 @@ func TestGraphCmd(t *testing.T) {
 	})
 
 	t.Run("override all defaults", func(t *testing.T) {
-		graphCmd := tf.graphCmd(context.Background(),
+		graphCmd, _ := tf.graphCmd(context.Background(),
 			GraphPlan("teststate"),
 			DrawCycles(true),
-			GraphType("output"),
-			ModuleDepth(2))
+			GraphType("output"))
+
+		assertCmd(t, []string{
+			"graph",
+			"teststate",
+			"-draw-cycles",
+			"-type=output",
+		}, nil, graphCmd)
+	})
+}
+
+func TestGraphCmd15(t *testing.T) {
+	td := t.TempDir()
+
+	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest015))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// empty env, to avoid environ mismatch in testing
+	tf.SetEnv(map[string]string{})
+
+	t.Run("defaults", func(t *testing.T) {
+		graphCmd, _ := tf.graphCmd(context.Background())
+
+		assertCmd(t, []string{
+			"graph",
+		}, nil, graphCmd)
+	})
+
+	t.Run("override all defaults", func(t *testing.T) {
+		graphCmd, _ := tf.graphCmd(context.Background(),
+			GraphPlan("teststate"),
+			DrawCycles(true),
+			GraphType("output"))
 
 		assertCmd(t, []string{
 			"graph",
 			"-plan=teststate",
 			"-draw-cycles",
 			"-type=output",
-			"-module-depth=2",
 		}, nil, graphCmd)
 	})
 }

--- a/tfexec/internal/e2etest/graph_test.go
+++ b/tfexec/internal/e2etest/graph_test.go
@@ -1,0 +1,29 @@
+package e2etest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/go-version"
+
+	"github.com/hashicorp/terraform-exec/tfexec"
+)
+
+func TestGraph(t *testing.T) {
+	runTest(t, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+		err := tf.Init(context.Background())
+		if err != nil {
+			t.Fatalf("error running Init in test directory: %s", err)
+		}
+
+		err = tf.Apply(context.Background())
+		if err != nil {
+			t.Fatalf("error running Apply: %s", err)
+		}
+
+		_, err = tf.Graph(context.Background())
+		if err != nil {
+			t.Fatalf("error running Graph: %s", err)
+		}
+	})
+}

--- a/tfexec/internal/e2etest/graph_test.go
+++ b/tfexec/internal/e2etest/graph_test.go
@@ -2,6 +2,7 @@ package e2etest
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/go-version"
@@ -21,9 +22,14 @@ func TestGraph(t *testing.T) {
 			t.Fatalf("error running Apply: %s", err)
 		}
 
-		_, err = tf.Graph(context.Background())
+		graphOutput, err := tf.Graph(context.Background())
 		if err != nil {
 			t.Fatalf("error running Graph: %s", err)
+		}
+
+		// Graph output differs slightly between versions, but resource subgraph remains consistent
+		if !strings.Contains(graphOutput, `"[root] null_resource.foo" [label = "null_resource.foo", shape = "box"]`) {
+			t.Fatalf("error running Graph. Graph output does not contain expected strings. Returned: %s", graphOutput)
 		}
 	})
 }

--- a/tfexec/options.go
+++ b/tfexec/options.go
@@ -206,15 +206,6 @@ func LockTimeout(lockTimeout string) *LockTimeoutOption {
 	return &LockTimeoutOption{lockTimeout}
 }
 
-type ModuleDepthOption struct {
-	moduleDepth int
-}
-
-// ModuleDepth represents the -module-depth option for graph command
-func ModuleDepth(moduleDepth int) *ModuleDepthOption {
-	return &ModuleDepthOption{moduleDepth}
-}
-
 type NetMirrorOption struct {
 	netMirror string
 }

--- a/tfexec/options.go
+++ b/tfexec/options.go
@@ -118,6 +118,15 @@ func Destroy(destroy bool) *DestroyFlagOption {
 	return &DestroyFlagOption{destroy}
 }
 
+type DrawCyclesOption struct {
+	drawCycles bool
+}
+
+// DrawCycles represents the -draw-cycles flag.
+func DrawCycles(drawCycles bool) *DrawCyclesOption {
+	return &DrawCyclesOption{drawCycles}
+}
+
 type DryRunOption struct {
 	dryRun bool
 }
@@ -197,6 +206,15 @@ func LockTimeout(lockTimeout string) *LockTimeoutOption {
 	return &LockTimeoutOption{lockTimeout}
 }
 
+type ModuleDepthOption struct {
+	moduleDepth int
+}
+
+// ModuleDepth represents the -module-depth option for graph command
+func ModuleDepth(moduleDepth int) *ModuleDepthOption {
+	return &ModuleDepthOption{moduleDepth}
+}
+
 type NetMirrorOption struct {
 	netMirror string
 }
@@ -220,6 +238,15 @@ type ParallelismOption struct {
 
 func Parallelism(n int) *ParallelismOption {
 	return &ParallelismOption{n}
+}
+
+type GraphPlanOption struct {
+	file string
+}
+
+// GraphPlan represents the -plan flag which is a specified plan file string
+func GraphPlan(file string) *GraphPlanOption {
+	return &GraphPlanOption{file}
 }
 
 type PlatformOption struct {
@@ -342,6 +369,14 @@ type TargetOption struct {
 
 func Target(resource string) *TargetOption {
 	return &TargetOption{resource}
+}
+
+type GraphTypeOption struct {
+	graphType string
+}
+
+func GraphType(graphType string) *GraphTypeOption {
+	return &GraphTypeOption{graphType}
 }
 
 type UpdateOption struct {

--- a/tfexec/version.go
+++ b/tfexec/version.go
@@ -15,8 +15,10 @@ import (
 
 var (
 	tf0_4_1  = version.Must(version.NewVersion("0.4.1"))
+	tf0_5_0  = version.Must(version.NewVersion("0.5.0"))
 	tf0_6_13 = version.Must(version.NewVersion("0.6.13"))
 	tf0_7_7  = version.Must(version.NewVersion("0.7.7"))
+	tf0_8_0  = version.Must(version.NewVersion("0.8.0"))
 	tf0_10_0 = version.Must(version.NewVersion("0.10.0"))
 	tf0_12_0 = version.Must(version.NewVersion("0.12.0"))
 	tf0_13_0 = version.Must(version.NewVersion("0.13.0"))


### PR DESCRIPTION
Implements the `graph` command for Terraform. At the moment, the output of the command is stored as just a string, but could potentially be loaded into an object that implements the DOT format.