### PR TITLE
Run force-unlock with -no-color flag

### DIFF
--- a/tfexec/force_unlock.go
+++ b/tfexec/force_unlock.go
@@ -36,7 +36,7 @@ func (tf *Terraform) forceUnlockCmd(ctx context.Context, lockID string, opts ...
 	for _, o := range opts {
 		o.configureForceUnlock(&c)
 	}
-	args := []string{"force-unlock", "-force"}
+	args := []string{"force-unlock", "-no-color", "-force"}
 
 	// positional arguments
 	args = append(args, lockID)


### PR DESCRIPTION
This adds the `-no-color` flag by default to the `force-unlock` command.

Without this patch we can get `ForceUnlock` error:
```
exit status 1
[31mFailed to unlock state: Lock ID should be numerical value, got 'ID'[0m[0m
```
With this patch the error becomes:
```
exit status 1
Failed to unlock state: Lock ID should be numerical value, got 'ID'
```
(I purposefully ran `ForceUnlock` with an invalid argument here to have it error out)