### PR TITLE
Add support for setting plugin cache directory

### DIFF
--- a/tfexec/cmd.go
+++ b/tfexec/cmd.go
@@ -15,17 +15,18 @@ import (
 )
 
 const (
-	checkpointDisableEnvVar  = "CHECKPOINT_DISABLE"
-	cliArgsEnvVar            = "TF_CLI_ARGS"
-	logEnvVar                = "TF_LOG"
-	inputEnvVar              = "TF_INPUT"
-	automationEnvVar         = "TF_IN_AUTOMATION"
-	logPathEnvVar            = "TF_LOG_PATH"
-	reattachEnvVar           = "TF_REATTACH_PROVIDERS"
-	appendUserAgentEnvVar    = "TF_APPEND_USER_AGENT"
-	workspaceEnvVar          = "TF_WORKSPACE"
-	disablePluginTLSEnvVar   = "TF_DISABLE_PLUGIN_TLS"
-	skipProviderVerifyEnvVar = "TF_SKIP_PROVIDER_VERIFY"
+	checkpointDisableEnvVar    = "CHECKPOINT_DISABLE"
+	cliArgsEnvVar              = "TF_CLI_ARGS"
+	logEnvVar                  = "TF_LOG"
+	inputEnvVar                = "TF_INPUT"
+	automationEnvVar           = "TF_IN_AUTOMATION"
+	logPathEnvVar              = "TF_LOG_PATH"
+	reattachEnvVar             = "TF_REATTACH_PROVIDERS"
+	appendUserAgentEnvVar      = "TF_APPEND_USER_AGENT"
+	workspaceEnvVar            = "TF_WORKSPACE"
+	disablePluginTLSEnvVar     = "TF_DISABLE_PLUGIN_TLS"
+	skipProviderVerifyEnvVar   = "TF_SKIP_PROVIDER_VERIFY"
+	pluginCacheDirectoryEnvVar = "TF_PLUGIN_CACHE_DIR"
 
 	varEnvVarPrefix    = "TF_VAR_"
 	cliArgEnvVarPrefix = "TF_CLI_ARGS_"
@@ -42,6 +43,7 @@ var prohibitedEnvVars = []string{
 	workspaceEnvVar,
 	disablePluginTLSEnvVar,
 	skipProviderVerifyEnvVar,
+	pluginCacheDirectoryEnvVar,
 }
 
 var prohibitedEnvVarPrefixes = []string{
@@ -165,6 +167,10 @@ func (tf *Terraform) buildEnv(mergeEnv map[string]string) []string {
 
 	if tf.skipProviderVerify {
 		env[skipProviderVerifyEnvVar] = "1"
+	}
+
+	if tf.pluginCacheDirectory != "" {
+		env[pluginCacheDirectoryEnvVar] = tf.pluginCacheDirectory
 	}
 
 	return envSlice(env)

--- a/tfexec/terraform.go
+++ b/tfexec/terraform.go
@@ -40,13 +40,15 @@ type printfer interface {
 //  - TF_REATTACH_PROVIDERS
 //  - TF_DISABLE_PLUGIN_TLS
 //  - TF_SKIP_PROVIDER_VERIFY
+//  - TF_PLUGIN_CACHE_DIR
 type Terraform struct {
-	execPath           string
-	workingDir         string
-	appendUserAgent    string
-	disablePluginTLS   bool
-	skipProviderVerify bool
-	env                map[string]string
+	execPath             string
+	workingDir           string
+	appendUserAgent      string
+	disablePluginTLS     bool
+	skipProviderVerify   bool
+	pluginCacheDirectory string
+	env                  map[string]string
 
 	stdout  io.Writer
 	stderr  io.Writer
@@ -151,6 +153,23 @@ func (tf *Terraform) SetSkipProviderVerify(skip bool) error {
 		return err
 	}
 	tf.skipProviderVerify = skip
+	return nil
+}
+
+// SetPluginCacheDirectory sets the TF_PLUGIN_CACHE_DIR environment variable
+// for Terraform CLI execution.
+func (tf *Terraform) SetPluginCacheDirectory(dir string) error {
+	err := tf.compatible(context.Background(), nil, tf0_10_7)
+	if err != nil {
+		return err
+	}
+	if dir == "" {
+		return fmt.Errorf("provider cache directory cannot be empty")
+	}
+	if _, err := os.Stat(dir); err != nil {
+		return fmt.Errorf("error initialising cache directory %s: %s", dir, err)
+	}
+	tf.pluginCacheDirectory = dir
 	return nil
 }
 

--- a/tfexec/version.go
+++ b/tfexec/version.go
@@ -20,6 +20,7 @@ var (
 	tf0_7_7  = version.Must(version.NewVersion("0.7.7"))
 	tf0_8_0  = version.Must(version.NewVersion("0.8.0"))
 	tf0_10_0 = version.Must(version.NewVersion("0.10.0"))
+	tf0_10_7 = version.Must(version.NewVersion("0.10.7"))
 	tf0_12_0 = version.Must(version.NewVersion("0.12.0"))
 	tf0_13_0 = version.Must(version.NewVersion("0.13.0"))
 	tf0_14_0 = version.Must(version.NewVersion("0.14.0"))


### PR DESCRIPTION
- Adds support for `TF_PLUGIN_CACHE_DIR` environment variable (introduced in [0.10.7](https://github.com/hashicorp/terraform/blob/v0.11/CHANGELOG.md#0107-october-2-2017))

I think this could also be an option on the `init` command -- whichever y'all think would be best!