### PR TITLE
bump v1 and v1.1 test versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ We strictly follow [semantic versioning](https://semver.org).
 
 This library is built in Go, and uses the [support policy](https://golang.org/doc/devel/release.html#policy) of Go as its support policy. The two latest major releases of Go are supported by terraform-exec.
 
-Currently, that means Go **1.16** or later must be used.
+Currently, that means Go **1.17** or later must be used.
 
 ## Usage
 

--- a/tfexec/cmd_default.go
+++ b/tfexec/cmd_default.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 package tfexec

--- a/tfexec/internal/testutil/tfcache.go
+++ b/tfexec/internal/testutil/tfcache.go
@@ -17,8 +17,8 @@ const (
 	Latest013   = "0.13.7"
 	Latest014   = "0.14.11"
 	Latest015   = "0.15.5"
-	Latest_v1   = "1.0.10"
-	Latest_v1_1 = "1.1.0-beta1"
+	Latest_v1   = "1.0.11"
+	Latest_v1_1 = "1.1.4"
 )
 
 const appendUserAgent = "tfexec-testutil"


### PR DESCRIPTION
All tests should pass except the known failure `TestShow_errNoInit` on main.