### PR TITLE
enable usage of generated commands externally

### DIFF
--- a/tfexec/apply.go
+++ b/tfexec/apply.go
@@ -92,14 +92,14 @@ func (opt *ReattachOption) configureApply(conf *applyConfig) {
 
 // Apply represents the terraform apply subcommand.
 func (tf *Terraform) Apply(ctx context.Context, opts ...ApplyOption) error {
-	cmd, err := tf.applyCmd(ctx, opts...)
+	cmd, err := tf.ApplyCmd(ctx, opts...)
 	if err != nil {
 		return err
 	}
 	return tf.runTerraformCmd(ctx, cmd)
 }
 
-func (tf *Terraform) applyCmd(ctx context.Context, opts ...ApplyOption) (*exec.Cmd, error) {
+func (tf *Terraform) ApplyCmd(ctx context.Context, opts ...ApplyOption) (*exec.Cmd, error) {
 	c := defaultApplyOptions
 
 	for _, o := range opts {

--- a/tfexec/apply_test.go
+++ b/tfexec/apply_test.go
@@ -19,7 +19,7 @@ func TestApplyCmd(t *testing.T) {
 	tf.SetEnv(map[string]string{})
 
 	t.Run("basic", func(t *testing.T) {
-		applyCmd, err := tf.applyCmd(context.Background(),
+		applyCmd, err := tf.ApplyCmd(context.Background(),
 			Backup("testbackup"),
 			LockTimeout("200s"),
 			State("teststate"),

--- a/tfexec/cmd_default.go
+++ b/tfexec/cmd_default.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 package tfexec
@@ -38,7 +39,7 @@ func (tf *Terraform) runTerraformCmd(ctx context.Context, cmd *exec.Cmd) error {
 		err = ctx.Err()
 	}
 	if err != nil {
-		return tf.wrapExitError(ctx, err, errBuf.String())
+		return tf.WrapExitError(ctx, err, errBuf.String())
 	}
 
 	return nil

--- a/tfexec/cmd_linux.go
+++ b/tfexec/cmd_linux.go
@@ -47,7 +47,7 @@ func (tf *Terraform) runTerraformCmd(ctx context.Context, cmd *exec.Cmd) error {
 		err = ctx.Err()
 	}
 	if err != nil {
-		return tf.wrapExitError(ctx, err, errBuf.String())
+		return tf.WrapExitError(ctx, err, errBuf.String())
 	}
 
 	return nil

--- a/tfexec/destroy.go
+++ b/tfexec/destroy.go
@@ -88,14 +88,14 @@ func (opt *ReattachOption) configureDestroy(conf *destroyConfig) {
 
 // Destroy represents the terraform destroy subcommand.
 func (tf *Terraform) Destroy(ctx context.Context, opts ...DestroyOption) error {
-	cmd, err := tf.destroyCmd(ctx, opts...)
+	cmd, err := tf.DestroyCmd(ctx, opts...)
 	if err != nil {
 		return err
 	}
 	return tf.runTerraformCmd(ctx, cmd)
 }
 
-func (tf *Terraform) destroyCmd(ctx context.Context, opts ...DestroyOption) (*exec.Cmd, error) {
+func (tf *Terraform) DestroyCmd(ctx context.Context, opts ...DestroyOption) (*exec.Cmd, error) {
 	c := defaultDestroyOptions
 
 	for _, o := range opts {

--- a/tfexec/destroy_test.go
+++ b/tfexec/destroy_test.go
@@ -19,7 +19,7 @@ func TestDestroyCmd(t *testing.T) {
 	tf.SetEnv(map[string]string{})
 
 	t.Run("defaults", func(t *testing.T) {
-		destroyCmd, err := tf.destroyCmd(context.Background())
+		destroyCmd, err := tf.DestroyCmd(context.Background())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -37,7 +37,7 @@ func TestDestroyCmd(t *testing.T) {
 	})
 
 	t.Run("override all defaults", func(t *testing.T) {
-		destroyCmd, err := tf.destroyCmd(context.Background(), Backup("testbackup"), LockTimeout("200s"), State("teststate"), StateOut("teststateout"), VarFile("testvarfile"), Lock(false), Parallelism(99), Refresh(false), Target("target1"), Target("target2"), Var("var1=foo"), Var("var2=bar"), Dir("destroydir"))
+		destroyCmd, err := tf.DestroyCmd(context.Background(), Backup("testbackup"), LockTimeout("200s"), State("teststate"), StateOut("teststateout"), VarFile("testvarfile"), Lock(false), Parallelism(99), Refresh(false), Target("target1"), Target("target2"), Var("var1=foo"), Var("var2=bar"), Dir("destroydir"))
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/tfexec/exit_errors.go
+++ b/tfexec/exit_errors.go
@@ -37,7 +37,7 @@ var (
 	stateLockInfoRegexp = regexp.MustCompile(`Lock Info:\n\s*ID:\s*([^\n]+)\n\s*Path:\s*([^\n]+)\n\s*Operation:\s*([^\n]+)\n\s*Who:\s*([^\n]+)\n\s*Version:\s*([^\n]+)\n\s*Created:\s*([^\n]+)\n`)
 )
 
-func (tf *Terraform) wrapExitError(ctx context.Context, err error, stderr string) error {
+func (tf *Terraform) WrapExitError(ctx context.Context, err error, stderr string) error {
 	exitErr, ok := err.(*exec.ExitError)
 	if !ok {
 		// not an exit error, short circuit, nothing to wrap

--- a/tfexec/init.go
+++ b/tfexec/init.go
@@ -94,14 +94,14 @@ func (opt *VerifyPluginsOption) configureInit(conf *initConfig) {
 
 // Init represents the terraform init subcommand.
 func (tf *Terraform) Init(ctx context.Context, opts ...InitOption) error {
-	cmd, err := tf.initCmd(ctx, opts...)
+	cmd, err := tf.InitCmd(ctx, opts...)
 	if err != nil {
 		return err
 	}
 	return tf.runTerraformCmd(ctx, cmd)
 }
 
-func (tf *Terraform) initCmd(ctx context.Context, opts ...InitOption) (*exec.Cmd, error) {
+func (tf *Terraform) InitCmd(ctx context.Context, opts ...InitOption) (*exec.Cmd, error) {
 	c := defaultInitOptions
 
 	for _, o := range opts {

--- a/tfexec/init_test.go
+++ b/tfexec/init_test.go
@@ -20,7 +20,7 @@ func TestInitCmd(t *testing.T) {
 
 	t.Run("defaults", func(t *testing.T) {
 		// defaults
-		initCmd, err := tf.initCmd(context.Background())
+		initCmd, err := tf.InitCmd(context.Background())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -41,7 +41,7 @@ func TestInitCmd(t *testing.T) {
 	})
 
 	t.Run("override all defaults", func(t *testing.T) {
-		initCmd, err := tf.initCmd(context.Background(), Backend(false), BackendConfig("confpath1"), BackendConfig("confpath2"), FromModule("testsource"), Get(false), GetPlugins(false), Lock(false), LockTimeout("999s"), PluginDir("testdir1"), PluginDir("testdir2"), Reconfigure(true), Upgrade(true), VerifyPlugins(false), Dir("initdir"))
+		initCmd, err := tf.InitCmd(context.Background(), Backend(false), BackendConfig("confpath1"), BackendConfig("confpath2"), FromModule("testsource"), Get(false), GetPlugins(false), Lock(false), LockTimeout("999s"), PluginDir("testdir1"), PluginDir("testdir2"), Reconfigure(true), Upgrade(true), VerifyPlugins(false), Dir("initdir"))
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/tfexec/plan.go
+++ b/tfexec/plan.go
@@ -97,7 +97,7 @@ func (opt *DestroyFlagOption) configurePlan(conf *planConfig) {
 // The returned error is nil if `terraform plan` has been executed and exits
 // with either 0 or 2.
 func (tf *Terraform) Plan(ctx context.Context, opts ...PlanOption) (bool, error) {
-	cmd, err := tf.planCmd(ctx, opts...)
+	cmd, err := tf.PlanCmd(ctx, opts...)
 	if err != nil {
 		return false, err
 	}
@@ -108,7 +108,7 @@ func (tf *Terraform) Plan(ctx context.Context, opts ...PlanOption) (bool, error)
 	return false, err
 }
 
-func (tf *Terraform) planCmd(ctx context.Context, opts ...PlanOption) (*exec.Cmd, error) {
+func (tf *Terraform) PlanCmd(ctx context.Context, opts ...PlanOption) (*exec.Cmd, error) {
 	c := defaultPlanOptions
 
 	for _, o := range opts {

--- a/tfexec/plan_test.go
+++ b/tfexec/plan_test.go
@@ -19,7 +19,7 @@ func TestPlanCmd(t *testing.T) {
 	tf.SetEnv(map[string]string{})
 
 	t.Run("defaults", func(t *testing.T) {
-		planCmd, err := tf.planCmd(context.Background())
+		planCmd, err := tf.PlanCmd(context.Background())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -37,7 +37,7 @@ func TestPlanCmd(t *testing.T) {
 	})
 
 	t.Run("override all defaults", func(t *testing.T) {
-		planCmd, err := tf.planCmd(context.Background(),
+		planCmd, err := tf.PlanCmd(context.Background(),
 			Destroy(true),
 			Lock(false),
 			LockTimeout("22s"),

--- a/tfexec/terraform_test.go
+++ b/tfexec/terraform_test.go
@@ -84,7 +84,7 @@ func TestCheckpointDisablePropagation(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		initCmd, err := tf.initCmd(context.Background())
+		initCmd, err := tf.InitCmd(context.Background())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -116,7 +116,7 @@ func TestCheckpointDisablePropagation(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		initCmd, err := tf.initCmd(context.Background())
+		initCmd, err := tf.InitCmd(context.Background())
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
This change enables consumers of terraform-exec to build commands using the library but execute them externally.  This allows for more flexibility and control of the command execution.