### PR TITLE
fix: Race condition on execution when context closes

### DIFF
--- a/tfexec/cmd.go
+++ b/tfexec/cmd.go
@@ -171,7 +171,7 @@ func (tf *Terraform) buildEnv(mergeEnv map[string]string) []string {
 }
 
 func (tf *Terraform) buildTerraformCmd(ctx context.Context, mergeEnv map[string]string, args ...string) *exec.Cmd {
-	cmd := exec.Command(tf.execPath, args...)
+	cmd := exec.CommandContext(ctx, tf.execPath, args...)
 
 	cmd.Env = tf.buildEnv(mergeEnv)
 	cmd.Dir = tf.workingDir

--- a/tfexec/cmd_default.go
+++ b/tfexec/cmd_default.go
@@ -17,7 +17,7 @@ func (tf *Terraform) runTerraformCmd(ctx context.Context, cmd *exec.Cmd) error {
 	go func() {
 		<-ctx.Done()
 		if ctx.Err() == context.DeadlineExceeded || ctx.Err() == context.Canceled {
-			if cmd != nil && cmd.Process != nil && cmd.ProcessState != nil {
+			if cmd != nil && cmd.Process != nil {
 				err := cmd.Process.Kill()
 				if err != nil {
 					tf.logger.Printf("error from kill: %s", err)

--- a/tfexec/cmd_default.go
+++ b/tfexec/cmd_default.go
@@ -14,18 +14,6 @@ func (tf *Terraform) runTerraformCmd(ctx context.Context, cmd *exec.Cmd) error {
 	cmd.Stdout = mergeWriters(cmd.Stdout, tf.stdout)
 	cmd.Stderr = mergeWriters(cmd.Stderr, tf.stderr, &errBuf)
 
-	go func() {
-		<-ctx.Done()
-		if ctx.Err() == context.DeadlineExceeded || ctx.Err() == context.Canceled {
-			if cmd != nil && cmd.Process != nil {
-				err := cmd.Process.Kill()
-				if err != nil {
-					tf.logger.Printf("error from kill: %s", err)
-				}
-			}
-		}
-	}()
-
 	// check for early cancellation
 	select {
 	case <-ctx.Done():

--- a/tfexec/cmd_linux.go
+++ b/tfexec/cmd_linux.go
@@ -20,21 +20,6 @@ func (tf *Terraform) runTerraformCmd(ctx context.Context, cmd *exec.Cmd) error {
 		Setpgid: true,
 	}
 
-	go func() {
-		<-ctx.Done()
-		if ctx.Err() == context.DeadlineExceeded || ctx.Err() == context.Canceled {
-			if cmd != nil && cmd.Process != nil {
-				// send SIGINT to process group
-				err := syscall.Kill(-cmd.Process.Pid, syscall.SIGINT)
-				if err != nil {
-					tf.logger.Printf("error from SIGINT: %s", err)
-				}
-			}
-
-			// TODO: send a kill if it doesn't respond for a bit?
-		}
-	}()
-
 	// check for early cancellation
 	select {
 	case <-ctx.Done():

--- a/tfexec/cmd_linux.go
+++ b/tfexec/cmd_linux.go
@@ -23,7 +23,7 @@ func (tf *Terraform) runTerraformCmd(ctx context.Context, cmd *exec.Cmd) error {
 	go func() {
 		<-ctx.Done()
 		if ctx.Err() == context.DeadlineExceeded || ctx.Err() == context.Canceled {
-			if cmd != nil && cmd.Process != nil && cmd.ProcessState != nil {
+			if cmd != nil && cmd.Process != nil {
 				// send SIGINT to process group
 				err := syscall.Kill(-cmd.Process.Pid, syscall.SIGINT)
 				if err != nil {


### PR DESCRIPTION
Accessing ProcessState on non-linux operating systems immediately
after context cancels can conflict with the Wait() stdlib func:
https://github.com/golang/go/blob/36b81acfa19d9fedf6a0cd60c394fd7a7703834e/src/os/exec/exec.go#L511