### PR TITLE
Clarify use of runTestVersions()

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,18 +34,6 @@ func (tf *Terraform) refreshCmd(ctx context.Context, opts ...RefreshCmdOption) (
 
 Command options are implemented using the functional variadic options pattern. For further reading on this pattern, please see [Functional options for friendly APIs](https://dave.cheney.net/2014/10/17/functional-options-for-friendly-apis) by Dave Cheney.
 
-### `tfinstall`
-
-Package `github.com/hashicorp/terraform-exec/tfinstall` offers multiple strategies for finding and/or installing a binary version of Terraform. Some of the strategies can also authenticate the source of the binary as an official HashiCorp release.
-
-**The public API of `tfinstall` is experimental and we welcome suggestions and ideas for its improvement, and accounts of current or proposed use cases.**
-
-As in `tfexec`, a variadic options pattern is used to supply a list of strategies for locating the Terraform executable. Each is implemented in a separate Go file. Our aim is to present a flexible and reasonably intuitive interface for ensuring a Terraform executable is available, with or without version constraints.
-
-### `cmd/tfinstall`
-
-Package `github.com/hashicorp/terraform-exec/cmd/tfinstall` has no public Go API and is distributed as a compiled binary which can be run to download and install a version of Terraform. 
-
 ## Testing
 
 We aim for full test coverage of all Terraform CLI commands implemented in `tfexec`, with as many combinations of command-line options as possible. New command implementations will not be merged without both unit and end-to-end tests.
@@ -82,7 +70,7 @@ The `github.com/hashicorp/terraform-exec` Go module in its entirety is versioned
 
 ## Releases
 
-Releases are made on a reasonably regular basis by the Terraform Plugin SDK team, using our custom CI workflows. There is currently no set release schedule and no requirement for contributors to write CHANGELOG entries.
+Releases are made on a reasonably regular basis by the Terraform team, using our custom CI workflows. There is currently no set release schedule and no requirement for contributors to write CHANGELOG entries.
 
 ## Security vulnerabilities
 
@@ -100,8 +88,6 @@ In general we do not accept PRs containing only the following changes:
  
 While we appreciate the effort that goes into preparing PRs, there is always a tradeoff between benefit and cost. The costs involved in accepting such contributions include the time taken for thorough review, the noise created in the git history, and the increased number of GitHub notifications that maintainers must attend to.
 
-In the case of `terraform-plugin-sdk`, the repo's close relationship to the `terraform` repo means that maintainers will sometimes port changes from `terraform` to `terraform-plugin-sdk`. Cosmetic changes to the SDK repo make this much more time-consuming as they will cause merge conflicts. This is the major hidden cost of cosmetic PRs, and the main reason we do not accept them at this time.
-
 #### Exceptions
 
-We belive that one should "leave the campsite cleaner than you found it", so you are welcome to clean up cosmetic issues in the neighbourhood when submitting a patch that makes functional changes or fixes.
+We believe that one should "leave the campsite cleaner than you found it", so you are welcome to clean up cosmetic issues in the neighbourhood when submitting a patch that makes functional changes or fixes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,9 +58,23 @@ Unit tests live alongside command implementations in `tfexec/`. A unit test asse
 
 End-to-end tests test both `tfinstall` and `tfexec`, using the former to install Terraform binaries according to various version constraints, and exercising the latter in as many combinations as possible, after real-world use cases.
 
-By default, each test is run against the latest versions of Terraform 0.11, Terraform 0.12, and Terraform 0.13. Copy an existing test and use the `runTest()` helper for this purpose.
+By default, each test is run against the latest patch versions of all Terraform minor version releases, starting at 0.11. Copy an existing test and use the `runTest()` helper for this purpose.
 
-If the command implemented differs in any way between Terraform versions (e.g. a flag is added or removed, or the subcommand does not exist in earlier versions), the `runTestVersions()` helper should be used to make both positive and negative assertions against the Terraform version being run, or skip the test as appropriate.
+#### Testing behaviour that differs between Terraform versions
+
+Subject to [compatibility guarantees](https://www.terraform.io/language/v1-compatibility-promises), each new version of Terraform CLI may:
+ - Add a command or flag not previously present
+ - Remove a command or flag
+ - Change stdout or stderr output
+ - Change the format of output files, e.g. the state file
+ - Change a command's exit code
+ 
+These and any other differences between versions should be specified in test assertions.
+
+If the command implemented differs in any way between Terraform versions (e.g. a flag is added or removed, or the subcommand does not exist in earlier versions), use `t.Skip()` directives and version checks to adapt test behaviour as appropriate. For example:
+https://github.com/hashicorp/terraform-exec/blob/d0cb3efafda90dd47bbfabdccde3cf7e45e0376d/tfexec/internal/e2etest/validate_test.go#L15-L23
+
+The `runTestVersions()` helper can be used to run tests against specific Terraform versions. This should be used only alongside a test using `runTest()` to cover the remaining past and future versions.
 
 ## Versioning
 

--- a/tfexec/internal/e2etest/providers_lock_test.go
+++ b/tfexec/internal/e2etest/providers_lock_test.go
@@ -7,11 +7,17 @@ import (
 	"github.com/hashicorp/go-version"
 
 	"github.com/hashicorp/terraform-exec/tfexec"
-	"github.com/hashicorp/terraform-exec/tfexec/internal/testutil"
+)
+
+var (
+	providersLockMinVersion = version.Must(version.NewVersion("0.14.0"))
 )
 
 func TestProvidersLock(t *testing.T) {
-	runTestVersions(t, []string{testutil.Latest014, testutil.Latest015, testutil.Latest_v1}, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTest(t, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+		if tfv.LessThan(providersLockMinVersion) {
+			t.Skip("terraform providers lock was added in Terraform 0.14, so test is not valid")
+		}
 		err := tf.Init(context.Background())
 		if err != nil {
 			t.Fatalf("error running Init in test directory: %s", err)


### PR DESCRIPTION
Update CONTRIBUTING.md with some more helpful information on how to write tests, and correct one use of `runTestVersions()`.