### PR TITLE
deps: Remove direct dependency on github.com/sergi/go-diff

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/hashicorp/go-version v1.4.0
 	github.com/hashicorp/hc-install v0.3.1
 	github.com/hashicorp/terraform-json v0.13.0
-	github.com/sergi/go-diff v1.2.0
 	github.com/zclconf/go-cty v1.10.0
 	github.com/zclconf/go-cty-debug v0.0.0-20191215020915-b22d67c1ba0b
 )
@@ -26,6 +25,7 @@ require (
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/kevinburke/ssh_config v0.0.0-20201106050909-4977a11b4351 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
+	github.com/sergi/go-diff v1.2.0 // indirect
 	github.com/xanzy/ssh-agent v0.3.0 // indirect
 	golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e // indirect
 	golang.org/x/net v0.0.0-20210326060303-6b1517762897 // indirect

--- a/tfexec/internal/e2etest/show_test.go
+++ b/tfexec/internal/e2etest/show_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io/ioutil"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/andybalholm/crlf"
@@ -608,7 +609,7 @@ func TestShowPlanFileRaw012_linux(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if diff := cmp.Diff(actual, expected); diff != "" {
+		if diff := cmp.Diff(strings.TrimSpace(actual), strings.TrimSpace(string(expected))); diff != "" {
 			t.Fatalf("unexpected difference: %s", diff)
 		}
 	})
@@ -637,7 +638,7 @@ func TestShowPlanFileRaw013(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if diff := cmp.Diff(actual, expected); diff != "" {
+		if diff := cmp.Diff(strings.TrimSpace(actual), strings.TrimSpace(string(expected))); diff != "" {
 			t.Fatalf("unexpected difference: %s", diff)
 		}
 	})
@@ -665,7 +666,7 @@ func TestShowPlanFileRaw014(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if diff := cmp.Diff(actual, expected); diff != "" {
+		if diff := cmp.Diff(strings.TrimSpace(actual), strings.TrimSpace(string(expected))); diff != "" {
 			t.Fatalf("unexpected difference: %s", diff)
 		}
 	})

--- a/tfexec/internal/e2etest/show_test.go
+++ b/tfexec/internal/e2etest/show_test.go
@@ -6,13 +6,12 @@ import (
 	"errors"
 	"io/ioutil"
 	"runtime"
-	"strings"
 	"testing"
 
 	"github.com/andybalholm/crlf"
+	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/go-version"
 	tfjson "github.com/hashicorp/terraform-json"
-	"github.com/sergi/go-diff/diffmatchpatch"
 
 	"github.com/hashicorp/terraform-exec/tfexec"
 	"github.com/hashicorp/terraform-exec/tfexec/internal/testutil"
@@ -609,10 +608,8 @@ func TestShowPlanFileRaw012_linux(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if strings.TrimSpace(actual) != strings.TrimSpace(string(expected)) {
-			dmp := diffmatchpatch.New()
-			diffs := dmp.DiffMain(strings.TrimSpace(actual), strings.TrimSpace(string(expected)), false)
-			t.Fatalf("actual:\n\n%s\n\nexpected:\n\n%s\n\ndiff:\n\n%s", actual, string(expected), dmp.DiffPrettyText(diffs))
+		if diff := cmp.Diff(actual, expected); diff != "" {
+			t.Fatalf("unexpected difference: %s", diff)
 		}
 	})
 }
@@ -640,10 +637,8 @@ func TestShowPlanFileRaw013(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if strings.TrimSpace(actual) != strings.TrimSpace(string(expected)) {
-			dmp := diffmatchpatch.New()
-			diffs := dmp.DiffMain(strings.TrimSpace(actual), strings.TrimSpace(string(expected)), false)
-			t.Fatalf("actual:\n\n%s\n\nexpected:\n\n%s\n\ndiff:\n\n%s", actual, string(expected), dmp.DiffPrettyText(diffs))
+		if diff := cmp.Diff(actual, expected); diff != "" {
+			t.Fatalf("unexpected difference: %s", diff)
 		}
 	})
 }
@@ -670,10 +665,8 @@ func TestShowPlanFileRaw014(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if strings.TrimSpace(actual) != strings.TrimSpace(string(expected)) {
-			dmp := diffmatchpatch.New()
-			diffs := dmp.DiffMain(strings.TrimSpace(actual), strings.TrimSpace(string(expected)), false)
-			t.Fatalf("actual:\n\n%s\n\nexpected:\n\n%s\n\ndiff:\n\n%s", actual, string(expected), dmp.DiffPrettyText(diffs))
+		if diff := cmp.Diff(actual, expected); diff != "" {
+			t.Fatalf("unexpected difference: %s", diff)
 		}
 	})
 }


### PR DESCRIPTION
It was only being used for "pretty" text differences in 3 tests. It is still an indirect dependency due to hc-install.

```console
$ go mod why -m github.com/sergi/go-diff
# github.com/sergi/go-diff
github.com/hashicorp/terraform-exec/tfexec/internal/testutil
github.com/hashicorp/hc-install/build
github.com/go-git/go-git/v5
github.com/sergi/go-diff/diffmatchpatch
```