### PR TITLE
apply: allow use of -destroy flag for compatible terraform versions

### DIFF
--- a/tfexec/apply_test.go
+++ b/tfexec/apply_test.go
@@ -38,6 +38,7 @@ func TestApplyCmd(t *testing.T) {
 			Target("target2"),
 			Var("var1=foo"),
 			Var("var2=bar"),
+			Destroy(true),
 			DirOrPlan("testfile"),
 		)
 		if err != nil {
@@ -60,6 +61,7 @@ func TestApplyCmd(t *testing.T) {
 			"-refresh=false",
 			"-replace=aws_instance.test",
 			"-replace=google_pubsub_topic.test",
+			"-destroy",
 			"-target=target1",
 			"-target=target2",
 			"-var", "var1=foo",

--- a/tfexec/internal/e2etest/apply_test.go
+++ b/tfexec/internal/e2etest/apply_test.go
@@ -15,6 +15,10 @@ import (
 	"github.com/hashicorp/terraform-exec/tfexec/internal/testutil"
 )
 
+var (
+	applyDestroyMinVersion = version.Must(version.NewVersion("0.15.2"))
+)
+
 func TestApply(t *testing.T) {
 	runTest(t, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
 		err := tf.Init(context.Background())
@@ -59,6 +63,28 @@ func TestApplyJSON_TF015AndLater(t *testing.T) {
 		err = tf.ApplyJSON(context.Background(), io.Discard)
 		if err != nil {
 			t.Fatalf("error running Apply: %s", err)
+		}
+	})
+}
+
+func TestApplyDestroy(t *testing.T) {
+	runTest(t, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+		if tfv.LessThan(applyDestroyMinVersion) {
+			t.Skip("terraform apply -destroy was added in Terraform 0.15.2, so test is not valid")
+		}
+		err := tf.Init(context.Background())
+		if err != nil {
+			t.Fatalf("error running Init in test directory: %s", err)
+		}
+
+		err = tf.Apply(context.Background())
+		if err != nil {
+			t.Fatalf("error running Apply: %s", err)
+		}
+
+		err = tf.Apply(context.Background(), tfexec.Destroy(true))
+		if err != nil {
+			t.Fatalf("error running Apply -destroy: %s", err)
 		}
 	})
 }


### PR DESCRIPTION
Implement the ApplyOption interface for the DestroyFlagOption
struct which enables the user to run `terraform apply -destroy`
as they would using the terraform binary directly by calling
`func (tf *Terraform) Apply`.