### PR TITLE
tests: fix missed testTempDir(t)

### DIFF
--- a/tfexec/state_pull_test.go
+++ b/tfexec/state_pull_test.go
@@ -8,9 +8,7 @@ import (
 )
 
 func TestStatePull(t *testing.T) {
-	td := testTempDir(t)
-
-	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest_v1))
+	tf, err := NewTerraform(t.TempDir(), tfVersion(t, testutil.Latest_v1))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tfexec/state_push_test.go
+++ b/tfexec/state_push_test.go
@@ -8,9 +8,7 @@ import (
 )
 
 func TestStatePushCmd(t *testing.T) {
-	td := testTempDir(t)
-
-	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest_v1))
+	tf, err := NewTerraform(t.TempDir(), tfVersion(t, testutil.Latest_v1))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Merging #215 added back some more references to `testTempDir`, removed in https://github.com/hashicorp/terraform-exec/commit/eccad43b4c2e218b66878810bfbe89b8b117d392.

Merging this should fix tests on `main`.