### PR TITLE
Test for runTerraformCmd leaked go-routine

### DIFF
--- a/tfexec/cmd.go
+++ b/tfexec/cmd.go
@@ -243,7 +243,7 @@ func writeOutput(r io.ReadCloser, w io.Writer) error {
 			}
 		}
 		if err != nil {
-			if errors.As(err, &io.EOF) {
+			if errors.Is(err, io.EOF) {
 				return nil
 			}
 

--- a/tfexec/cmd.go
+++ b/tfexec/cmd.go
@@ -233,7 +233,21 @@ func mergeWriters(writers ...io.Writer) io.Writer {
 	return io.MultiWriter(compact...)
 }
 
-func writeOutput(r io.ReadCloser, w io.Writer) error {
+func writeOutput(ctx context.Context, r io.ReadCloser, w io.Writer) error {
+	// ReadBytes will block until bytes are read, which can cause a delay in
+	// returning even if the command's context has been canceled. Use a separate
+	// goroutine to prompt ReadBytes to return on cancel
+	closeCtx, closeCancel := context.WithCancel(ctx)
+	defer closeCancel()
+	go func() {
+		select {
+		case <-ctx.Done():
+			r.Close()
+		case <-closeCtx.Done():
+			return
+		}
+	}()
+
 	buf := bufio.NewReader(r)
 	for {
 		line, err := buf.ReadBytes('\n')

--- a/tfexec/cmd.go
+++ b/tfexec/cmd.go
@@ -173,7 +173,7 @@ func (tf *Terraform) buildEnv(mergeEnv map[string]string) []string {
 }
 
 func (tf *Terraform) buildTerraformCmd(ctx context.Context, mergeEnv map[string]string, args ...string) *exec.Cmd {
-	cmd := exec.Command(tf.execPath, args...)
+	cmd := exec.CommandContext(ctx, tf.execPath, args...)
 
 	cmd.Env = tf.buildEnv(mergeEnv)
 	cmd.Dir = tf.workingDir

--- a/tfexec/cmd.go
+++ b/tfexec/cmd.go
@@ -1,9 +1,11 @@
 package tfexec
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -229,4 +231,23 @@ func mergeWriters(writers ...io.Writer) io.Writer {
 		return compact[0]
 	}
 	return io.MultiWriter(compact...)
+}
+
+func writeOutput(r io.ReadCloser, w io.Writer) error {
+	buf := bufio.NewReader(r)
+	for {
+		line, err := buf.ReadBytes('\n')
+		if len(line) > 0 {
+			if _, err := w.Write(line); err != nil {
+				return err
+			}
+		}
+		if err != nil {
+			if errors.As(err, &io.EOF) {
+				return nil
+			}
+
+			return err
+		}
+	}
 }

--- a/tfexec/cmd_default.go
+++ b/tfexec/cmd_default.go
@@ -12,14 +12,10 @@ import (
 func (tf *Terraform) runTerraformCmd(ctx context.Context, cmd *exec.Cmd) error {
 	var errBuf strings.Builder
 
-	cmd.Stdout = mergeWriters(cmd.Stdout, tf.stdout)
-	cmd.Stderr = mergeWriters(cmd.Stderr, tf.stderr, &errBuf)
-
 	go func() {
 		<-ctx.Done()
 		if ctx.Err() == context.DeadlineExceeded || ctx.Err() == context.Canceled {
 			if cmd != nil && cmd.Process != nil {
-				tf.logger.Printf("killing process. cmd.ProcessState=%v", cmd.ProcessState)
 				err := cmd.Process.Kill()
 				if err != nil {
 					tf.logger.Printf("error from kill: %s", err)
@@ -35,7 +31,43 @@ func (tf *Terraform) runTerraformCmd(ctx context.Context, cmd *exec.Cmd) error {
 	default:
 	}
 
-	err := cmd.Run()
+	// Read stdout / stderr logs from pipe instead of setting cmd.Stdout and
+	// cmd.Stderr because it can cause hanging when killing the command
+	// https://github.com/golang/go/issues/23019
+	stdoutWriter := mergeWriters(cmd.Stdout, tf.stdout)
+	stderrWriter := mergeWriters(tf.stderr, &errBuf)
+
+	cmd.Stderr = nil
+	cmd.Stdout = nil
+
+	stdoutPipe, err := cmd.StdoutPipe()
+	if err != nil {
+		return err
+	}
+
+	stderrPipe, err := cmd.StderrPipe()
+	if err != nil {
+		return err
+	}
+
+	err = cmd.Start()
+	if err == nil && ctx.Err() != nil {
+		err = ctx.Err()
+	}
+	if err != nil {
+		return tf.wrapExitError(ctx, err, "")
+	}
+
+	exitChLen := 2
+	exitCh := make(chan error, exitChLen)
+	go func() {
+		exitCh <- writeOutput(stdoutPipe, stdoutWriter)
+	}()
+	go func() {
+		exitCh <- writeOutput(stderrPipe, stderrWriter)
+	}()
+
+	err = cmd.Wait()
 	if err == nil && ctx.Err() != nil {
 		err = ctx.Err()
 	}
@@ -43,5 +75,16 @@ func (tf *Terraform) runTerraformCmd(ctx context.Context, cmd *exec.Cmd) error {
 		return tf.wrapExitError(ctx, err, errBuf.String())
 	}
 
-	return nil
+	// Wait for the logs to finish writing
+	counter := 0
+	for {
+		counter++
+		err := <-exitCh
+		if err != nil && err != context.Canceled {
+			return tf.wrapExitError(ctx, err, errBuf.String())
+		}
+		if counter >= exitChLen {
+			return ctx.Err()
+		}
+	}
 }

--- a/tfexec/cmd_default.go
+++ b/tfexec/cmd_default.go
@@ -12,18 +12,6 @@ import (
 func (tf *Terraform) runTerraformCmd(ctx context.Context, cmd *exec.Cmd) error {
 	var errBuf strings.Builder
 
-	go func() {
-		<-ctx.Done()
-		if ctx.Err() == context.DeadlineExceeded || ctx.Err() == context.Canceled {
-			if cmd != nil && cmd.Process != nil {
-				err := cmd.Process.Kill()
-				if err != nil {
-					tf.logger.Printf("error from kill: %s", err)
-				}
-			}
-		}
-	}()
-
 	// check for early cancellation
 	select {
 	case <-ctx.Done():

--- a/tfexec/cmd_default.go
+++ b/tfexec/cmd_default.go
@@ -18,7 +18,8 @@ func (tf *Terraform) runTerraformCmd(ctx context.Context, cmd *exec.Cmd) error {
 	go func() {
 		<-ctx.Done()
 		if ctx.Err() == context.DeadlineExceeded || ctx.Err() == context.Canceled {
-			if cmd != nil && cmd.Process != nil && cmd.ProcessState != nil {
+			if cmd != nil && cmd.Process != nil {
+				tf.logger.Printf("killing process. cmd.ProcessState=%v", cmd.ProcessState)
 				err := cmd.Process.Kill()
 				if err != nil {
 					tf.logger.Printf("error from kill: %s", err)

--- a/tfexec/cmd_default_test.go
+++ b/tfexec/cmd_default_test.go
@@ -1,0 +1,39 @@
+//go:build !linux
+// +build !linux
+
+package tfexec
+
+import (
+	"bytes"
+	"context"
+	"log"
+	"strings"
+	"testing"
+	"time"
+)
+
+func Test_runTerraformCmd_default(t *testing.T) {
+	// Checks runTerraformCmd for race condition when using
+	// go test -race -run Test_runTerraformCmd_default ./tfexec
+	var buf bytes.Buffer
+
+	tf := &Terraform{
+		logger:   log.New(&buf, "", 0),
+		execPath: "echo",
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	cmd := tf.buildTerraformCmd(ctx, nil, "hello tf-exec!")
+	err := tf.runTerraformCmd(ctx, cmd)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Cancel stops the leaked go routine which logs an error
+	cancel()
+	time.Sleep(time.Second)
+	if strings.Contains(buf.String(), "error from kill") {
+		t.Fatal("canceling context should not lead to logging an error")
+	}
+}

--- a/tfexec/cmd_linux.go
+++ b/tfexec/cmd_linux.go
@@ -10,9 +10,6 @@ import (
 func (tf *Terraform) runTerraformCmd(ctx context.Context, cmd *exec.Cmd) error {
 	var errBuf strings.Builder
 
-	cmd.Stdout = mergeWriters(cmd.Stdout, tf.stdout)
-	cmd.Stderr = mergeWriters(cmd.Stderr, tf.stderr, &errBuf)
-
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		// kill children if parent is dead
 		Pdeathsig: syscall.SIGKILL,
@@ -24,7 +21,6 @@ func (tf *Terraform) runTerraformCmd(ctx context.Context, cmd *exec.Cmd) error {
 		<-ctx.Done()
 		if ctx.Err() == context.DeadlineExceeded || ctx.Err() == context.Canceled {
 			if cmd != nil && cmd.Process != nil {
-				tf.logger.Printf("killing process. cmd.ProcessState=%v", cmd.ProcessState)
 				// send SIGINT to process group
 				err := syscall.Kill(-cmd.Process.Pid, syscall.SIGINT)
 				if err != nil {
@@ -43,7 +39,43 @@ func (tf *Terraform) runTerraformCmd(ctx context.Context, cmd *exec.Cmd) error {
 	default:
 	}
 
-	err := cmd.Run()
+	// Read stdout / stderr logs from pipe instead of setting cmd.Stdout and
+	// cmd.Stderr because it can cause hanging when killing the command
+	// https://github.com/golang/go/issues/23019
+	stdoutWriter := mergeWriters(cmd.Stdout, tf.stdout)
+	stderrWriter := mergeWriters(tf.stderr, &errBuf)
+
+	cmd.Stderr = nil
+	cmd.Stdout = nil
+
+	stdoutPipe, err := cmd.StdoutPipe()
+	if err != nil {
+		return err
+	}
+
+	stderrPipe, err := cmd.StderrPipe()
+	if err != nil {
+		return err
+	}
+
+	err = cmd.Start()
+	if err == nil && ctx.Err() != nil {
+		err = ctx.Err()
+	}
+	if err != nil {
+		return tf.wrapExitError(ctx, err, "")
+	}
+
+	exitChLen := 2
+	exitCh := make(chan error, exitChLen)
+	go func() {
+		exitCh <- writeOutput(stdoutPipe, stdoutWriter)
+	}()
+	go func() {
+		exitCh <- writeOutput(stderrPipe, stderrWriter)
+	}()
+
+	err = cmd.Wait()
 	if err == nil && ctx.Err() != nil {
 		err = ctx.Err()
 	}
@@ -51,5 +83,16 @@ func (tf *Terraform) runTerraformCmd(ctx context.Context, cmd *exec.Cmd) error {
 		return tf.wrapExitError(ctx, err, errBuf.String())
 	}
 
-	return nil
+	// Wait for the logs to finish writing
+	counter := 0
+	for {
+		counter++
+		err := <-exitCh
+		if err != nil && err != context.Canceled {
+			return tf.wrapExitError(ctx, err, errBuf.String())
+		}
+		if counter >= exitChLen {
+			return ctx.Err()
+		}
+	}
 }

--- a/tfexec/cmd_linux.go
+++ b/tfexec/cmd_linux.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os/exec"
 	"strings"
+	"sync"
 	"syscall"
 )
 
@@ -51,14 +52,23 @@ func (tf *Terraform) runTerraformCmd(ctx context.Context, cmd *exec.Cmd) error {
 		return tf.wrapExitError(ctx, err, "")
 	}
 
-	exitChLen := 2
-	exitCh := make(chan error, exitChLen)
+	var errStdout, errStderr error
+	var wg sync.WaitGroup
+	wg.Add(1)
 	go func() {
-		exitCh <- writeOutput(stdoutPipe, stdoutWriter)
+		defer wg.Done()
+		errStdout = writeOutput(ctx, stdoutPipe, stdoutWriter)
 	}()
+
+	wg.Add(1)
 	go func() {
-		exitCh <- writeOutput(stderrPipe, stderrWriter)
+		defer wg.Done()
+		errStderr = writeOutput(ctx, stderrPipe, stderrWriter)
 	}()
+
+	// Reads from pipes must be completed before calling cmd.Wait(). Otherwise
+	// can cause a race condition
+	wg.Wait()
 
 	err = cmd.Wait()
 	if err == nil && ctx.Err() != nil {
@@ -68,16 +78,13 @@ func (tf *Terraform) runTerraformCmd(ctx context.Context, cmd *exec.Cmd) error {
 		return tf.wrapExitError(ctx, err, errBuf.String())
 	}
 
-	// Wait for the logs to finish writing
-	counter := 0
-	for {
-		counter++
-		err := <-exitCh
-		if err != nil && err != context.Canceled {
-			return tf.wrapExitError(ctx, err, errBuf.String())
-		}
-		if counter >= exitChLen {
-			return ctx.Err()
-		}
+	// Return error if there was an issue reading the std out/err
+	if errStdout != nil && ctx.Err() != nil {
+		return tf.wrapExitError(ctx, errStdout, errBuf.String())
 	}
+	if errStderr != nil && ctx.Err() != nil {
+		return tf.wrapExitError(ctx, errStderr, errBuf.String())
+	}
+
+	return nil
 }

--- a/tfexec/cmd_linux.go
+++ b/tfexec/cmd_linux.go
@@ -23,7 +23,8 @@ func (tf *Terraform) runTerraformCmd(ctx context.Context, cmd *exec.Cmd) error {
 	go func() {
 		<-ctx.Done()
 		if ctx.Err() == context.DeadlineExceeded || ctx.Err() == context.Canceled {
-			if cmd != nil && cmd.Process != nil && cmd.ProcessState != nil {
+			if cmd != nil && cmd.Process != nil {
+				tf.logger.Printf("killing process. cmd.ProcessState=%v", cmd.ProcessState)
 				// send SIGINT to process group
 				err := syscall.Kill(-cmd.Process.Pid, syscall.SIGINT)
 				if err != nil {

--- a/tfexec/cmd_linux.go
+++ b/tfexec/cmd_linux.go
@@ -17,21 +17,6 @@ func (tf *Terraform) runTerraformCmd(ctx context.Context, cmd *exec.Cmd) error {
 		Setpgid: true,
 	}
 
-	go func() {
-		<-ctx.Done()
-		if ctx.Err() == context.DeadlineExceeded || ctx.Err() == context.Canceled {
-			if cmd != nil && cmd.Process != nil {
-				// send SIGINT to process group
-				err := syscall.Kill(-cmd.Process.Pid, syscall.SIGINT)
-				if err != nil {
-					tf.logger.Printf("error from SIGINT: %s", err)
-				}
-			}
-
-			// TODO: send a kill if it doesn't respond for a bit?
-		}
-	}()
-
 	// check for early cancellation
 	select {
 	case <-ctx.Done():

--- a/tfexec/cmd_linux_test.go
+++ b/tfexec/cmd_linux_test.go
@@ -1,0 +1,36 @@
+package tfexec
+
+import (
+	"bytes"
+	"context"
+	"log"
+	"strings"
+	"testing"
+	"time"
+)
+
+func Test_runTerraformCmd_linux(t *testing.T) {
+	// Checks runTerraformCmd for race condition when using
+	// go test -race -run Test_runTerraformCmd_linux ./tfexec -tags=linux
+	var buf bytes.Buffer
+
+	tf := &Terraform{
+		logger:   log.New(&buf, "", 0),
+		execPath: "echo",
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	cmd := tf.buildTerraformCmd(ctx, nil, "hello tf-exec!")
+	err := tf.runTerraformCmd(ctx, cmd)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Cancel stops the leaked go routine which logs an error
+	cancel()
+	time.Sleep(time.Second)
+	if strings.Contains(buf.String(), "error from kill") {
+		t.Fatal("canceling context should not lead to logging an error")
+	}
+}

--- a/tfexec/internal/e2etest/util_test.go
+++ b/tfexec/internal/e2etest/util_test.go
@@ -91,16 +91,21 @@ func runTestVersions(t *testing.T, versions []string, fixtureName string, cb fun
 				}
 			}
 
-			var stdouterr strings.Builder
-			tf.SetStdout(&stdouterr)
-			tf.SetStderr(&stdouterr)
+			// Separate strings.Builder because it's not concurrent safe
+			var stdout strings.Builder
+			tf.SetStdout(&stdout)
+			var stderr strings.Builder
+			tf.SetStderr(&stderr)
 
 			tf.SetLogger(&testingPrintfer{t})
 
 			// TODO: capture panics here?
 			cb(t, runningVersion, tf)
 
-			t.Logf("CLI Output:\n%s", stdouterr.String())
+			t.Logf("CLI Output:\n%s", stdout.String())
+			if len(stderr.String()) > 0 {
+				t.Logf("CLI Error:\n%s", stderr.String())
+			}
 		})
 	}
 }


### PR DESCRIPTION
This PR intends to showcase the issue fixed by https://github.com/hashicorp/terraform-exec/pull/276:

- Commit 1-3: **all part of [#301](https://github.com/hashicorp/terraform-exec/pull/301)** (Sorry, I didn't realize becauseI forked, I couldn't create this PR off of my other branch)
- Commit 4: added a test which captures the issue; test fails
- Commit 5: cherry-picked commits from #276 that address the issue; test passes

**If the changes in #276 look good, can close this PR in favor of merging #276.** The tests added in this PR aren't very meaning and lose context once the fix is merged.

### Issue details:

Currently, when runTerraformCmd is called, it starts a go-routine to kill the
Terraform CLI on context.Done(). However, when the Terraform CLI completes and
runTerraformCmd() finishes, the go-routine continues running unnecessarily.

If the caller cancels the context down the line, this will stop the go-routine
and it will log the error: "error from kill: os: process already finished" because
the Terraform CLI has already finished.

Added a test for this in cmd_default.go and cmd_linux.go. Have not tried it in
linux yet though.

Note: it's possible to see the race with pre-existing tests e.g. `go test -race -run TestContext_sleepTimeoutExpired ./tfexec/internal/e2etest -v`

When running with the race detector for `Test_runTerraformCmd_default`:
```
==================
WARNING: DATA RACE
Read at 0x00c0002516c8 by goroutine 7:
  bytes.(*Buffer).String()
      /usr/local/go/src/bytes/buffer.go:65 +0x36a
  github.com/hashicorp/terraform-exec/tfexec.Test_runTerraformCmd_default()
      /Users/lornasong/go/src/github.com/hashicorp/terraform-exec/tfexec/cmd_default_test.go:35 +0x360
  testing.tRunner()
  // truncated ...

Previous write at 0x00c0002516c8 by goroutine 8:
  bytes.(*Buffer).grow()
      /usr/local/go/src/bytes/buffer.go:147 +0x3b1
  bytes.(*Buffer).Write()
      /usr/local/go/src/bytes/buffer.go:172 +0xcd
  log.(*Logger).Output()
      /usr/local/go/src/log/log.go:184 +0x466
  log.(*Logger).Printf()
      /usr/local/go/src/log/log.go:191 +0x6e
  github.com/hashicorp/terraform-exec/tfexec.(*Terraform).runTerraformCmd.func1()
      /Users/lornasong/go/src/github.com/hashicorp/terraform-exec/tfexec/cmd_default.go:24 +0x2a5
  // truncated ...
==================
--- FAIL: Test_runTerraformCmd_default (1.01s)
    cmd_default_test.go:35:
                Error Trace:    cmd_default_test.go:35
                Error:          "[INFO] running Terraform command: /bin/echo hello tf-exec!
                                error from kill: os: process already finished
                                " should not contain "error from kill"
                Test:           Test_runTerraformCmd_default
    testing.go:1152: race detected during execution of test
```

Closes #258
Closes #276