### PR TITLE
make tests pass (or skip) on darwin/arm64

### DIFF
--- a/tfexec/destroy_test.go
+++ b/tfexec/destroy_test.go
@@ -10,7 +10,7 @@ import (
 func TestDestroyCmd(t *testing.T) {
 	td := t.TempDir()
 
-	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest012))
+	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest_v1))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tfexec/fmt_test.go
+++ b/tfexec/fmt_test.go
@@ -3,10 +3,15 @@ package tfexec
 import (
 	"context"
 	"errors"
+	"runtime"
 	"testing"
 )
 
 func TestFormat(t *testing.T) {
+	if runtime.GOOS == "darwin" && runtime.GOARCH == "arm64" {
+		t.Skip("Terraform for darwin/arm64 is not available until v1")
+	}
+
 	td := t.TempDir()
 
 	tf, err := NewTerraform(td, tfVersion(t, "0.7.6"))

--- a/tfexec/get_test.go
+++ b/tfexec/get_test.go
@@ -10,7 +10,7 @@ import (
 func TestGetCmd(t *testing.T) {
 	td := t.TempDir()
 
-	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest012))
+	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest_v1))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tfexec/graph_test.go
+++ b/tfexec/graph_test.go
@@ -2,12 +2,17 @@ package tfexec
 
 import (
 	"context"
+	"runtime"
 	"testing"
 
 	"github.com/hashicorp/terraform-exec/tfexec/internal/testutil"
 )
 
-func TestGraphCmd(t *testing.T) {
+func TestGraphCmd_v013(t *testing.T) {
+	if runtime.GOOS == "darwin" && runtime.GOARCH == "arm64" {
+		t.Skip("Terraform for darwin/arm64 is not available until v1")
+	}
+
 	td := t.TempDir()
 
 	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest013))
@@ -41,10 +46,10 @@ func TestGraphCmd(t *testing.T) {
 	})
 }
 
-func TestGraphCmd15(t *testing.T) {
+func TestGraphCmd_v1(t *testing.T) {
 	td := t.TempDir()
 
-	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest015))
+	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest_v1))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tfexec/import_test.go
+++ b/tfexec/import_test.go
@@ -10,7 +10,7 @@ import (
 func TestImportCmd(t *testing.T) {
 	td := t.TempDir()
 
-	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest012))
+	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest_v1))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tfexec/init_test.go
+++ b/tfexec/init_test.go
@@ -73,3 +73,57 @@ func TestInitCmd_v012(t *testing.T) {
 		}, nil, initCmd)
 	})
 }
+
+func TestInitCmd_v1(t *testing.T) {
+	td := t.TempDir()
+
+	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest_v1))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// empty env, to avoid environ mismatch in testing
+	tf.SetEnv(map[string]string{})
+
+	t.Run("defaults", func(t *testing.T) {
+		// defaults
+		initCmd, err := tf.initCmd(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assertCmd(t, []string{
+			"init",
+			"-no-color",
+			"-force-copy",
+			"-input=false",
+			"-backend=true",
+			"-get=true",
+			"-upgrade=false",
+		}, nil, initCmd)
+	})
+
+	t.Run("override all defaults", func(t *testing.T) {
+		initCmd, err := tf.initCmd(context.Background(), Backend(false), BackendConfig("confpath1"), BackendConfig("confpath2"), FromModule("testsource"), Get(false), PluginDir("testdir1"), PluginDir("testdir2"), Reconfigure(true), Upgrade(true), Dir("initdir"))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assertCmd(t, []string{
+			"init",
+			"-no-color",
+			"-force-copy",
+			"-input=false",
+			"-from-module=testsource",
+			"-backend=false",
+			"-get=false",
+			"-upgrade=true",
+			"-reconfigure",
+			"-backend-config=confpath1",
+			"-backend-config=confpath2",
+			"-plugin-dir=testdir1",
+			"-plugin-dir=testdir2",
+			"initdir",
+		}, nil, initCmd)
+	})
+}

--- a/tfexec/init_test.go
+++ b/tfexec/init_test.go
@@ -2,12 +2,17 @@ package tfexec
 
 import (
 	"context"
+	"runtime"
 	"testing"
 
 	"github.com/hashicorp/terraform-exec/tfexec/internal/testutil"
 )
 
-func TestInitCmd(t *testing.T) {
+func TestInitCmd_v012(t *testing.T) {
+	if runtime.GOOS == "darwin" && runtime.GOARCH == "arm64" {
+		t.Skip("Terraform for darwin/arm64 is not available until v1")
+	}
+
 	td := t.TempDir()
 
 	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest012))

--- a/tfexec/internal/e2etest/show_test.go
+++ b/tfexec/internal/e2etest/show_test.go
@@ -670,9 +670,6 @@ func TestShowPlanFileRaw014(t *testing.T) {
 }
 
 func TestShowBigInt(t *testing.T) {
-	if runtime.GOOS == "darwin" && runtime.GOARCH == "arm64" {
-		t.Skip("TODO")
-	}
 	runTest(t, "bigint", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
 		if tfv.LessThan(showMinVersion) {
 			t.Skip("terraform show was added in Terraform 0.12, so test is not valid")

--- a/tfexec/internal/e2etest/show_test.go
+++ b/tfexec/internal/e2etest/show_test.go
@@ -670,6 +670,9 @@ func TestShowPlanFileRaw014(t *testing.T) {
 }
 
 func TestShowBigInt(t *testing.T) {
+	if runtime.GOOS == "darwin" && runtime.GOARCH == "arm64" {
+		t.Skip("TODO")
+	}
 	runTest(t, "bigint", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
 		if tfv.LessThan(showMinVersion) {
 			t.Skip("terraform show was added in Terraform 0.12, so test is not valid")

--- a/tfexec/internal/e2etest/testdata/bigint/main.tf
+++ b/tfexec/internal/e2etest/testdata/bigint/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     random = {
-      version = "3.0.1"
+      version = "3.1.3"
     }
   }
 }

--- a/tfexec/internal/e2etest/util_test.go
+++ b/tfexec/internal/e2etest/util_test.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -50,6 +51,16 @@ func runTestVersions(t *testing.T, versions []string, fixtureName string, cb fun
 	alreadyRunVersions := map[string]bool{}
 	for _, tfv := range versions {
 		t.Run(fmt.Sprintf("%s-%s", fixtureName, tfv), func(t *testing.T) {
+			if runtime.GOOS == "darwin" && runtime.GOARCH == "arm64" {
+				v, err := version.NewVersion(tfv)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if v.LessThan(version.Must(version.NewVersion("1.0.2"))) {
+					t.Skipf("Terraform not available for darwin/arm64 < 1.0.2 (%s)", v)
+				}
+			}
+
 			if alreadyRunVersions[tfv] {
 				t.Skipf("already run version %q", tfv)
 			}

--- a/tfexec/output_test.go
+++ b/tfexec/output_test.go
@@ -10,7 +10,7 @@ import (
 func TestOutputCmd(t *testing.T) {
 	td := t.TempDir()
 
-	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest012))
+	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest_v1))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tfexec/providers_lock_test.go
+++ b/tfexec/providers_lock_test.go
@@ -10,7 +10,7 @@ import (
 func TestProvidersLockCmd(t *testing.T) {
 	td := t.TempDir()
 
-	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest012))
+	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest_v1))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tfexec/providers_schema_test.go
+++ b/tfexec/providers_schema_test.go
@@ -10,7 +10,7 @@ import (
 func TestProvidersSchemaCmd(t *testing.T) {
 	td := t.TempDir()
 
-	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest012))
+	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest_v1))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tfexec/refresh_test.go
+++ b/tfexec/refresh_test.go
@@ -10,7 +10,7 @@ import (
 func TestRefreshCmd(t *testing.T) {
 	td := t.TempDir()
 
-	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest013))
+	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest_v1))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tfexec/show_test.go
+++ b/tfexec/show_test.go
@@ -10,7 +10,7 @@ import (
 func TestShowCmd(t *testing.T) {
 	td := t.TempDir()
 
-	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest012))
+	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest_v1))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -31,7 +31,7 @@ func TestShowCmd(t *testing.T) {
 func TestShowStateFileCmd(t *testing.T) {
 	td := t.TempDir()
 
-	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest012))
+	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest_v1))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -52,7 +52,7 @@ func TestShowStateFileCmd(t *testing.T) {
 func TestShowPlanFileCmd(t *testing.T) {
 	td := t.TempDir()
 
-	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest012))
+	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest_v1))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -73,7 +73,7 @@ func TestShowPlanFileCmd(t *testing.T) {
 func TestShowPlanFileRawCmd(t *testing.T) {
 	td := t.TempDir()
 
-	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest012))
+	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest_v1))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tfexec/state_mv_test.go
+++ b/tfexec/state_mv_test.go
@@ -10,7 +10,7 @@ import (
 func TestStateMvCmd(t *testing.T) {
 	td := t.TempDir()
 
-	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest013))
+	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest_v1))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tfexec/state_rm_test.go
+++ b/tfexec/state_rm_test.go
@@ -10,7 +10,7 @@ import (
 func TestStateRmCmd(t *testing.T) {
 	td := t.TempDir()
 
-	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest013))
+	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest_v1))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tfexec/taint_test.go
+++ b/tfexec/taint_test.go
@@ -10,7 +10,7 @@ import (
 func TestTaintCmd(t *testing.T) {
 	td := t.TempDir()
 
-	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest013))
+	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest_v1))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tfexec/terraform_test.go
+++ b/tfexec/terraform_test.go
@@ -32,7 +32,7 @@ func TestMain(m *testing.M) {
 func TestSetEnv(t *testing.T) {
 	td := t.TempDir()
 
-	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest012))
+	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest_v1))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -273,6 +273,10 @@ func TestSetLogPath(t *testing.T) {
 }
 
 func TestCheckpointDisablePropagation(t *testing.T) {
+	if runtime.GOOS == "darwin" && runtime.GOARCH == "arm64" {
+		t.Skip("Terraform for darwin/arm64 is not available until v1")
+	}
+
 	td := t.TempDir()
 
 	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest012))

--- a/tfexec/untaint_test.go
+++ b/tfexec/untaint_test.go
@@ -10,7 +10,7 @@ import (
 func TestUntaintCmd(t *testing.T) {
 	td := t.TempDir()
 
-	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest013))
+	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest_v1))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tfexec/upgrade012_test.go
+++ b/tfexec/upgrade012_test.go
@@ -4,12 +4,17 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"runtime"
 	"testing"
 
 	"github.com/hashicorp/terraform-exec/tfexec/internal/testutil"
 )
 
 func TestUpgrade012(t *testing.T) {
+	if runtime.GOOS == "darwin" && runtime.GOARCH == "arm64" {
+		t.Skip("Terraform for darwin/arm64 is not available until v1")
+	}
+
 	td := t.TempDir()
 
 	t.Run("defaults", func(t *testing.T) {

--- a/tfexec/upgrade013_test.go
+++ b/tfexec/upgrade013_test.go
@@ -4,12 +4,17 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"runtime"
 	"testing"
 
 	"github.com/hashicorp/terraform-exec/tfexec/internal/testutil"
 )
 
 func TestUpgrade013(t *testing.T) {
+	if runtime.GOOS == "darwin" && runtime.GOARCH == "arm64" {
+		t.Skip("Terraform for darwin/arm64 is not available until v1")
+	}
+
 	td := t.TempDir()
 
 	t.Run("defaults", func(t *testing.T) {

--- a/tfexec/version_test.go
+++ b/tfexec/version_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -207,6 +208,10 @@ func TestVersionInRange(t *testing.T) {
 }
 
 func TestCompatible(t *testing.T) {
+	if runtime.GOOS == "darwin" && runtime.GOARCH == "arm64" {
+		t.Skip("Terraform for darwin/arm64 is not available until v1")
+	}
+
 	ev := &releases.ExactVersion{
 		Product: product.Terraform,
 		Version: version.Must(version.NewVersion("0.12.26")),

--- a/tfexec/workspace_delete_test.go
+++ b/tfexec/workspace_delete_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestWorkspaceDeleteCmd(t *testing.T) {
-	tf, err := NewTerraform(t.TempDir(), tfVersion(t, testutil.Latest013))
+	tf, err := NewTerraform(t.TempDir(), tfVersion(t, testutil.Latest_v1))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tfexec/workspace_new_test.go
+++ b/tfexec/workspace_new_test.go
@@ -11,7 +11,7 @@ import (
 func TestWorkspaceNewCmd(t *testing.T) {
 	td := t.TempDir()
 
-	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest013))
+	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest_v1))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tfexec/workspace_show_test.go
+++ b/tfexec/workspace_show_test.go
@@ -3,10 +3,15 @@ package tfexec
 import (
 	"context"
 	"errors"
+	"runtime"
 	"testing"
 )
 
 func TestWorkspaceShowCmd(t *testing.T) {
+	if runtime.GOOS == "darwin" && runtime.GOARCH == "arm64" {
+		t.Skip("Terraform for darwin/arm64 is not available until v1")
+	}
+
 	td := t.TempDir()
 
 	tf, err := NewTerraform(td, tfVersion(t, "0.9.11"))


### PR DESCRIPTION
**Why?**
Prior to this patch, many tests would fail for the same reason - attempt to install older version of Terraform which isn't available for darwin/arm64.

For example:
```
--- FAIL: TestDestroyCmd (0.08s)
    terraform_test.go:164: caching exec "v:0.12.31" in dir "/var/folders/9w/pddq2x656j76vxvsbhcs4nwr0000gq/T/tfinstall1718612104/v-0.12.31"
panic: error installing terraform "v:0.12.31": no ZIP archive found for terraform <nil> darwin/arm64 [recovered]
	panic: error installing terraform "v:0.12.31": no ZIP archive found for terraform <nil> darwin/arm64

goroutine 99 [running]:
testing.tRunner.func1.2({0x102b2d280, 0x1400038cb80})
	/opt/homebrew/Cellar/go/1.18.1/libexec/src/testing/testing.go:1389 +0x1c8
testing.tRunner.func1()
	/opt/homebrew/Cellar/go/1.18.1/libexec/src/testing/testing.go:1392 +0x384
panic({0x102b2d280, 0x1400038cb80})
	/opt/homebrew/Cellar/go/1.18.1/libexec/src/runtime/panic.go:838 +0x204
github.com/hashicorp/terraform-exec/tfexec/internal/testutil.(*TFCache).find(0x140002ca0c0, 0x14000003d40, {0x140004cc690, 0x9}, 0x14000077ea0)
	/Users/radeksimko/gopath/src/github.com/hashicorp/terraform-exec/tfexec/internal/testutil/tfcache_find.go:47 +0x374
github.com/hashicorp/terraform-exec/tfexec/internal/testutil.(*TFCache).Version(0x102b2d280?, 0x14000003d40, {0x1029fefa5, 0x7})
	/Users/radeksimko/gopath/src/github.com/hashicorp/terraform-exec/tfexec/internal/testutil/tfcache.go:61 +0x90
github.com/hashicorp/terraform-exec/tfexec.tfVersion(0x14000003d40?, {0x1029fefa5?, 0x14000067f48?})
	/Users/radeksimko/gopath/src/github.com/hashicorp/terraform-exec/tfexec/terraform_test.go:164 +0x88
github.com/hashicorp/terraform-exec/tfexec.TestDestroyCmd(0x14000003d40)
	/Users/radeksimko/gopath/src/github.com/hashicorp/terraform-exec/tfexec/destroy_test.go:13 +0x44
testing.tRunner(0x14000003d40, 0x102bf6820)
	/opt/homebrew/Cellar/go/1.18.1/libexec/src/testing/testing.go:1439 +0x110
created by testing.(*T).Run
	/opt/homebrew/Cellar/go/1.18.1/libexec/src/testing/testing.go:1486 +0x300
FAIL	github.com/hashicorp/terraform-exec/tfexec	6.097s
```

**Alternatives**
 - We could build Terraform as part of running relevant tests. That would likely add to the test time, increase the complexity of already complex matrix of versions throughout all packages and risk that a particular version may simply not work on darwin/arm64 as it was never properly tested.
 - We could update _all_ tests to use v1.0.2+ which _have_ darwin/arm64 builds, but there are still tests for older TF versions which may be useful to run.

**Solution**

I tried to strike the balance and bump TF version where it was possible/easy to do and skipped test where it wasn't.

--- 

I wish we could run any arm64 tests in CI, but AFAIK GitHub Actions don't offer that (yet).