### PR TITLE
ci: Test with -race flag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,12 +26,12 @@ commands:
   go_unit_test:
     steps:
       - run:
-          command: go test $(go list ./... | grep -v /tfexec/internal/e2etest)
+          command: go test -race $(go list ./... | grep -v /tfexec/internal/e2etest)
   go_e2e_test:
     steps:
       - run:
-          no_output_timeout: 20m
-          command: go test -timeout=20m -v ./tfexec/internal/e2etest
+          no_output_timeout: 30m
+          command: go test -race -timeout=30m -v ./tfexec/internal/e2etest
 
 jobs:
   # combined due to slowness of Go install


### PR DESCRIPTION
This ensures that we don't reintroduce race conditions, which were recently addressed in https://github.com/hashicorp/terraform-exec/pull/299

`go test -race` tends to take longer than without the flag, so I also pre-emptively increased the timeout for the E2E test run.