### PR TITLE
Fix for state_push: path for statefile is reqired for run state push cmd

### DIFF
--- a/tfexec/state_push.go
+++ b/tfexec/state_push.go
@@ -61,5 +61,7 @@ func (tf *Terraform) statePushCmd(ctx context.Context, path string, opts ...Stat
 		args = append(args, "-lock-timeout="+c.lockTimeout)
 	}
 
+	args = append(args, path)
+
 	return tf.buildTerraformCmd(ctx, nil, args...), nil
 }

--- a/tfexec/state_push_test.go
+++ b/tfexec/state_push_test.go
@@ -26,6 +26,7 @@ func TestStatePushCmd(t *testing.T) {
 			"push",
 			"-lock=false",
 			"-lock-timeout=0s",
+			"testpath",
 		}, nil, statePushCmd)
 	})
 
@@ -41,6 +42,7 @@ func TestStatePushCmd(t *testing.T) {
 			"-force",
 			"-lock=true",
 			"-lock-timeout=10s",
+			"testpath",
 		}, nil, statePushCmd)
 	})
 }


### PR DESCRIPTION
_terrafrom state push command_ expect statefile path.
If it not specified it will fail with "Exactly one argument expected"

documentation link: https://www.terraform.io/cli/commands/state/push#usage