### PR TITLE
tfexec/internal/e2etest: Skip TestShow_noInitEtcdBackend on >=1.3.0 and prereleases

### DIFF
--- a/tfexec/internal/e2etest/show_test.go
+++ b/tfexec/internal/e2etest/show_test.go
@@ -185,7 +185,7 @@ func TestShow_noInitModule(t *testing.T) {
 	})
 }
 
-func TestShow_noInitNonLocalBackend(t *testing.T) {
+func TestShow_noInitInmemBackend(t *testing.T) {
 	runTest(t, "inmem_backend", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
 		if tfv.LessThan(showMinVersion) {
 			t.Skip("terraform show was added in Terraform 0.12, so test is not valid")
@@ -213,8 +213,40 @@ func TestShow_noInitLocalBackendNonDefaultState(t *testing.T) {
 	})
 }
 
+func TestShow_noInitCloudBackend(t *testing.T) {
+	runTest(t, "cloud_backend", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+		if tfv.LessThan(version.Must(version.NewVersion("1.1.0"))) {
+			t.Skip("cloud backend was added in Terraform 1.1, so test is not valid")
+		}
+
+		var noInit *tfexec.ErrNoInit
+		_, err := tf.Show(context.Background())
+		if !errors.As(err, &noInit) {
+			t.Fatalf("expected error ErrNoInit, got %T: %s", err, err)
+		}
+	})
+}
+
 func TestShow_noInitEtcdBackend(t *testing.T) {
 	runTest(t, "etcd_backend", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+		if tfv.LessThan(showMinVersion) {
+			t.Skip("terraform show was added in Terraform 0.12, so test is not valid")
+		}
+
+		if tfv.GreaterThanOrEqual(version.Must(version.NewVersion("1.3.0"))) || tfv.Prerelease() != "" {
+			t.Skip("etcd backend was removed in Terraform 1.3, so test is not valid")
+		}
+
+		var noInit *tfexec.ErrNoInit
+		_, err := tf.Show(context.Background())
+		if !errors.As(err, &noInit) {
+			t.Fatalf("expected error ErrNoInit, got %T: %s", err, err)
+		}
+	})
+}
+
+func TestShow_noInitRemoteBackend(t *testing.T) {
+	runTest(t, "remote_backend", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
 		if tfv.LessThan(showMinVersion) {
 			t.Skip("terraform show was added in Terraform 0.12, so test is not valid")
 		}

--- a/tfexec/internal/e2etest/testdata/cloud_backend/main.tf
+++ b/tfexec/internal/e2etest/testdata/cloud_backend/main.tf
@@ -1,0 +1,4 @@
+terraform {
+  backend "cloud" {
+  }
+}

--- a/tfexec/internal/e2etest/testdata/remote_backend/main.tf
+++ b/tfexec/internal/e2etest/testdata/remote_backend/main.tf
@@ -1,0 +1,4 @@
+terraform {
+  backend "remote" {
+  }
+}


### PR DESCRIPTION
Reference: https://github.com/hashicorp/terraform/pull/31326

Fixes the new test failures against Terraform `main` branch. This also adds testing for the `cloud` and `remote` backends, which should be more stable as they are integral to the Terraform experience.

Previously:

```console
$ TFEXEC_E2ETEST_VERSIONS=refs/heads/main go test -count=1 -run='TestShow_noInitEtcdBackend' -v ./tfexec/internal/e2etest
=== RUN   TestShow_noInitEtcdBackend
=== RUN   TestShow_noInitEtcdBackend/etcd_backend-refs/heads/main
    util_test.go:112: caching exec "gitref:refs/heads/main" in dir "/var/folders/w8/05f3x02n27x72g0mc2jy6_180000gp/T/tfinstall2067874872/gitref-refs-heads-main"
2022/06/30 15:56:57 git_revision.go:88: running terraform pre-clone check (timeout: 1m0s)
2022/06/30 15:56:57 git_revision.go:94: terraform pre-clone check finished
2022/06/30 15:56:57 git_revision.go:123: cloning terraform repository from https://github.com/hashicorp/terraform.git to /var/folders/w8/05f3x02n27x72g0mc2jy6_180000gp/T/hc-install-build-terraform3971808670 (timeout: 5m0s)
2022/06/30 15:57:37 git_revision.go:136: cloning terraform finished
2022/06/30 15:57:37 git_revision.go:142: terraform repository HEAD is at acb79a75451e39126f1cdc596ff802a91d64d712
2022/06/30 15:57:37 git_revision.go:169: building terraform (timeout: 10m0s)
2022/06/30 15:57:37 go_build.go:55: executing go ["build" "-o" "/var/folders/w8/05f3x02n27x72g0mc2jy6_180000gp/T/hc-install-terraform-acb79a75451e39126f1cdc596ff802a91d64d7123048666161/terraform"] in "/var/folders/w8/05f3x02n27x72g0mc2jy6_180000gp/T/hc-install-build-terraform3971808670"
2022/06/30 15:57:51 git_revision.go:171: building of terraform finished
    util_test.go:173: [INFO] running Terraform command: /var/folders/w8/05f3x02n27x72g0mc2jy6_180000gp/T/hc-install-terraform-acb79a75451e39126f1cdc596ff802a91d64d7123048666161/terraform show -json -no-color
    show_test.go:232: expected error ErrNoInit, got *fmt.wrapError: exit status 1

        Error: Invalid backend type

          on main.tf line 2, in terraform:
           2:   backend "etcd" {

        The "etcd" backend is not supported in Terraform v1.3 or later.
--- FAIL: TestShow_noInitEtcdBackend (55.76s)
    --- FAIL: TestShow_noInitEtcdBackend/etcd_backend-refs/heads/main (55.76s)
FAIL
FAIL    github.com/hashicorp/terraform-exec/tfexec/internal/e2etest     56.060s
FAIL
```

After change:

```console
$ TFEXEC_E2ETEST_VERSIONS=refs/heads/main go test -count=1 -run='TestShow_noInitEtcdBackend' -v ./tfexec/internal/e2etest
=== RUN   TestShow_noInitEtcdBackend
=== RUN   TestShow_noInitEtcdBackend/etcd_backend-refs/heads/main
    util_test.go:112: caching exec "gitref:refs/heads/main" in dir "/var/folders/w8/05f3x02n27x72g0mc2jy6_180000gp/T/tfinstall2843106250/gitref-refs-heads-main"
2022/06/30 15:59:17 git_revision.go:88: running terraform pre-clone check (timeout: 1m0s)
2022/06/30 15:59:17 git_revision.go:94: terraform pre-clone check finished
2022/06/30 15:59:17 git_revision.go:123: cloning terraform repository from https://github.com/hashicorp/terraform.git to /var/folders/w8/05f3x02n27x72g0mc2jy6_180000gp/T/hc-install-build-terraform22313428 (timeout: 5m0s)
2022/06/30 15:59:59 git_revision.go:136: cloning terraform finished
2022/06/30 15:59:59 git_revision.go:142: terraform repository HEAD is at acb79a75451e39126f1cdc596ff802a91d64d712
2022/06/30 15:59:59 git_revision.go:169: building terraform (timeout: 10m0s)
2022/06/30 15:59:59 go_build.go:55: executing go ["build" "-o" "/var/folders/w8/05f3x02n27x72g0mc2jy6_180000gp/T/hc-install-terraform-acb79a75451e39126f1cdc596ff802a91d64d7122130413204/terraform"] in "/var/folders/w8/05f3x02n27x72g0mc2jy6_180000gp/T/hc-install-build-terraform22313428"
2022/06/30 16:00:12 git_revision.go:171: building of terraform finished
    show_test.go:223: etcd backend was removed in Terraform 1.3, so test is not valid
--- PASS: TestShow_noInitEtcdBackend (56.66s)
    --- SKIP: TestShow_noInitEtcdBackend/etcd_backend-refs/heads/main (56.66s)
PASS
ok      github.com/hashicorp/terraform-exec/tfexec/internal/e2etest     57.704s
```