### PR TITLE
ci: fix macos builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
   # combined due to slowness of Go install
   macosbuildtest:
     macos:
-      xcode: "12.5.1"
+      xcode: "13.4.1"
     steps:
       - macos_install_go
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
   # combined due to slowness of Go install
   macosbuildtest:
     macos:
-      xcode: "12.0.0"
+      xcode: "12.5.1"
     steps:
       - macos_install_go
       - checkout

--- a/tfexec/fmt_test.go
+++ b/tfexec/fmt_test.go
@@ -2,19 +2,20 @@ package tfexec
 
 import (
 	"context"
-	"errors"
 	"runtime"
 	"testing"
+
+	"github.com/hashicorp/terraform-exec/tfexec/internal/testutil"
 )
 
-func TestFormat(t *testing.T) {
+func TestFormatCmd(t *testing.T) {
 	if runtime.GOOS == "darwin" && runtime.GOARCH == "arm64" {
 		t.Skip("Terraform for darwin/arm64 is not available until v1")
 	}
 
 	td := t.TempDir()
 
-	tf, err := NewTerraform(td, tfVersion(t, "0.7.6"))
+	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest_v1_1))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -22,15 +23,34 @@ func TestFormat(t *testing.T) {
 	// empty env, to avoid environ mismatch in testing
 	tf.SetEnv(map[string]string{})
 
-	t.Run("too old version", func(t *testing.T) {
-		_, err := tf.formatCmd(context.Background(), []string{})
-		if err == nil {
-			t.Fatal("expected old version to fail")
+	t.Run("defaults", func(t *testing.T) {
+		fmtCmd, err := tf.formatCmd(context.Background(), []string{})
+		if err != nil {
+			t.Fatal(err)
 		}
 
-		var expectedErr *ErrVersionMismatch
-		if !errors.As(err, &expectedErr) {
-			t.Fatalf("error doesn't match: %#v", err)
+		assertCmd(t, []string{
+			"fmt",
+			"-no-color",
+		}, nil, fmtCmd)
+	})
+
+	t.Run("override all defaults", func(t *testing.T) {
+		fmtCmd, err := tf.formatCmd(context.Background(),
+			[]string{"string1", "string2"},
+			Recursive(true),
+			Dir("mydir"))
+		if err != nil {
+			t.Fatal(err)
 		}
+
+		assertCmd(t, []string{
+			"fmt",
+			"-no-color",
+			"string1",
+			"string2",
+			"-recursive",
+			"mydir",
+		}, nil, fmtCmd)
 	})
 }

--- a/tfexec/workspace_show_test.go
+++ b/tfexec/workspace_show_test.go
@@ -2,39 +2,10 @@ package tfexec
 
 import (
 	"context"
-	"errors"
-	"runtime"
 	"testing"
 
 	"github.com/hashicorp/terraform-exec/tfexec/internal/testutil"
 )
-
-func TestWorkspaceShowCmd_v012(t *testing.T) {
-	if runtime.GOOS == "darwin" && runtime.GOARCH == "arm64" {
-		t.Skip("Terraform for darwin/arm64 is not available until v1")
-	}
-
-	td := t.TempDir()
-
-	tf, err := NewTerraform(td, tfVersion(t, "0.9.11"))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// empty env, to avoid environ mismatch in testing
-	tf.SetEnv(map[string]string{})
-
-	_, err = tf.workspaceShowCmd(context.Background())
-	if err == nil {
-		t.Fatal("expected old version to fail")
-	}
-
-	var expectedErr *ErrVersionMismatch
-	if !errors.As(err, &expectedErr) {
-		t.Fatalf("error doesn't match: %#v", err)
-	}
-
-}
 
 func TestWorkspaceShowCmd_v1(t *testing.T) {
 	td := t.TempDir()


### PR DESCRIPTION
This PR now upgrades the macOS runner to the latest stable version of Xcode, v13.4.1, and removes two tests. This fixes the failing nightly build.

The two tests removed are:
 - `TestFormat`
   - This downloaded Terraform v0.7.6 and verified that running `Format()` resulted in a compatibility error, since `fmt` was only added in v0.7.7.
   - Replaced with basic "defaults" tests and renamed to `TestFormatCmd`
 - `TestWorkspaceShowCmd_v012`
   - This downloaded Terraform v0.9.11 and verified that running `WorkspaceShow()` resulted in a compat error, since `workspace show` was only added in v0.10.0.

While we should be extremely reluctant to remove tests, in this case these tests were preventing us from testing all other Terraform behaviour on newer macOS environments (assuming we did not run two separate macOS test environments).

In addition, the compatibility behaviour being tested is common across all commands, being just a call to `tf.compatible()`, which is tested in several other places.

Please see below for more details about why we can no longer use such old Terraform binaries in acceptance testing on macOS.

## Old description

Commit https://github.com/hashicorp/terraform-exec/pull/327/commits/cb2badc5d848516a3b379ba2aa59d3707a78de40 is preserved to show this approach.

Certain terraform-exec tests run versions of Terraform earlier than 0.12 in order to test compatibility behaviour. These versions of Terraform are compiled with Go < 1.11.

Any version of Terraform complied with Go < 1.11 causes errors when run on macOS Monterey 12 or later, which corresponds to Xcode version 13 or later. Please see the following pages for more information:
https://github.com/golang/go/wiki/MacOS12BSDThreadRegisterIssue
https://xcodereleases.com/

We must therefore use Xcode 12 for these tests. CircleCI supports only the latest stable version, currently v12.5.1.

When Xcode 16 is released, CircleCI will drop support for Xcode 12 (https://circleci.com/docs/xcode-policy), so we will need to resolve this problem another way.