### PR TITLE
Support graceful cancellation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ func (tf *Terraform) Refresh(ctx context.Context, opts ...RefreshCmdOption) erro
 
 func (tf *Terraform) refreshCmd(ctx context.Context, opts ...RefreshCmdOption) (*exec.Cmd, error) {
 	...
-  	return tf.buildTerraformCmd(ctx, mergeEnv, args...), nil
+  	return tf.buildTerraformCmd( mergeEnv, args...), nil
 }
 ```
 

--- a/tfexec/apply.go
+++ b/tfexec/apply.go
@@ -165,5 +165,5 @@ func (tf *Terraform) applyCmd(ctx context.Context, opts ...ApplyOption) (*exec.C
 		mergeEnv[reattachEnvVar] = reattachStr
 	}
 
-	return tf.buildTerraformCmd(ctx, mergeEnv, args...), nil
+	return tf.buildTerraformCmd(mergeEnv, args...), nil
 }

--- a/tfexec/apply_test.go
+++ b/tfexec/apply_test.go
@@ -3,6 +3,7 @@ package tfexec
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-exec/tfexec/internal/testutil"
 )
@@ -19,7 +20,7 @@ func TestApplyCmd(t *testing.T) {
 	tf.SetEnv(map[string]string{})
 
 	t.Run("basic", func(t *testing.T) {
-		applyCmd, err := tf.applyCmd(context.Background(),
+		applyCmd, applyOpts, err := tf.applyCmd(context.Background(),
 			Backup("testbackup"),
 			LockTimeout("200s"),
 			State("teststate"),
@@ -36,6 +37,7 @@ func TestApplyCmd(t *testing.T) {
 			Var("var1=foo"),
 			Var("var2=bar"),
 			DirOrPlan("testfile"),
+			GracefulShutdownTimeout(10*time.Second),
 		)
 		if err != nil {
 			t.Fatal(err)
@@ -63,5 +65,10 @@ func TestApplyCmd(t *testing.T) {
 			"-var", "var2=bar",
 			"testfile",
 		}, nil, applyCmd)
+
+		if applyOpts.gracefulShutdownTimeout != 10*time.Second {
+			t.Fatalf("graceful shutdown timeout mismatch\n\nexpected:\n%v\n\ngot:\n%v", 10*time.Second, applyOpts.gracefulShutdownTimeout)
+		}
 	})
+
 }

--- a/tfexec/cmd.go
+++ b/tfexec/cmd.go
@@ -179,8 +179,8 @@ func (tf *Terraform) buildEnv(mergeEnv map[string]string) []string {
 	return envSlice(env)
 }
 
-func (tf *Terraform) buildTerraformCmd(ctx context.Context, mergeEnv map[string]string, args ...string) *exec.Cmd {
-	cmd := exec.CommandContext(ctx, tf.execPath, args...)
+func (tf *Terraform) buildTerraformCmd(mergeEnv map[string]string, args ...string) *exec.Cmd {
+	cmd := exec.Command(tf.execPath, args...)
 
 	cmd.Env = tf.buildEnv(mergeEnv)
 	cmd.Dir = tf.workingDir

--- a/tfexec/cmd_default.go
+++ b/tfexec/cmd_default.go
@@ -5,7 +5,7 @@ package tfexec
 
 import (
 	"context"
-	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"strings"
@@ -55,7 +55,7 @@ func (tf *Terraform) runTerraformCmdWithGracefulshutdownTimeout(ctx context.Cont
 		select {
 		case <-ctx.Done(): // wait for context cancelled
 			cmd.Process.Signal(os.Kill)
-			returnCh <- errors.New("terraform forcefully killed")
+			returnCh <- fmt.Errorf("%w: terraform forcefully killed", ctx.Err())
 		case err := <-cmdDoneCh:
 			returnCh <- err
 		}

--- a/tfexec/cmd_default_test.go
+++ b/tfexec/cmd_default_test.go
@@ -24,7 +24,7 @@ func Test_runTerraformCmd_default(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 
-	cmd := tf.buildTerraformCmd(ctx, nil, "hello tf-exec!")
+	cmd := tf.buildTerraformCmd(nil, "hello tf-exec!")
 	err := tf.runTerraformCmd(ctx, cmd)
 	if err != nil {
 		t.Fatal(err)

--- a/tfexec/cmd_default_test.go
+++ b/tfexec/cmd_default_test.go
@@ -6,6 +6,7 @@ package tfexec
 import (
 	"bytes"
 	"context"
+	"errors"
 	"log"
 	"strings"
 	"testing"
@@ -35,5 +36,26 @@ func Test_runTerraformCmd_default(t *testing.T) {
 	time.Sleep(time.Second)
 	if strings.Contains(buf.String(), "error from kill") {
 		t.Fatal("canceling context should not lead to logging an error")
+	}
+}
+
+func Test_runTerraformCmdCancelCtx_default(t *testing.T) {
+	var buf bytes.Buffer
+
+	tf := &Terraform{
+		logger:   log.New(&buf, "", 0),
+		execPath: "sleep",
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cmd := tf.buildTerraformCmd(nil, "3")
+	go func() {
+		<-time.After(1 * time.Second)
+		cancel()
+	}()
+	err := tf.runTerraformCmd(ctx, cmd)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %T %s", err, err)
 	}
 }

--- a/tfexec/cmd_linux.go
+++ b/tfexec/cmd_linux.go
@@ -2,7 +2,7 @@ package tfexec
 
 import (
 	"context"
-	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"strings"
@@ -81,9 +81,9 @@ func (tf *Terraform) runTerraformCmdWithGracefulshutdownTimeout(parentCtx contex
 				}
 				cancel() // to cancel stdout/stderr writers
 				tf.logger.Printf("[ERROR] terraform forcefully killed after graceful shutdown timeout")
-				returnCh <- errors.New("terraform forcefully killed after graceful shutdown timeout")
+				returnCh <- fmt.Errorf("%w: terraform forcefully killed after graceful shutdown timeout", parentCtx.Err())
 			case err := <-cmdDoneCh:
-				returnCh <- err
+				returnCh <- fmt.Errorf("%w: %v", parentCtx.Err(), err)
 				tf.logger.Printf("[INFO] terraform successfully interrupted")
 			}
 		case err := <-cmdDoneCh:

--- a/tfexec/cmd_linux_test.go
+++ b/tfexec/cmd_linux_test.go
@@ -21,7 +21,7 @@ func Test_runTerraformCmd_linux(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 
-	cmd := tf.buildTerraformCmd(ctx, nil, "hello tf-exec!")
+	cmd := tf.buildTerraformCmd(nil, "hello tf-exec!")
 	err := tf.runTerraformCmd(ctx, cmd)
 	if err != nil {
 		t.Fatal(err)

--- a/tfexec/destroy.go
+++ b/tfexec/destroy.go
@@ -152,5 +152,5 @@ func (tf *Terraform) destroyCmd(ctx context.Context, opts ...DestroyOption) (*ex
 		mergeEnv[reattachEnvVar] = reattachStr
 	}
 
-	return tf.buildTerraformCmd(ctx, mergeEnv, args...), nil
+	return tf.buildTerraformCmd(mergeEnv, args...), nil
 }

--- a/tfexec/fmt.go
+++ b/tfexec/fmt.go
@@ -155,5 +155,5 @@ func (tf *Terraform) formatCmd(ctx context.Context, args []string, opts ...Forma
 		args = append(args, c.dir)
 	}
 
-	return tf.buildTerraformCmd(ctx, nil, args...), nil
+	return tf.buildTerraformCmd(nil, args...), nil
 }

--- a/tfexec/force_unlock.go
+++ b/tfexec/force_unlock.go
@@ -54,5 +54,5 @@ func (tf *Terraform) forceUnlockCmd(ctx context.Context, lockID string, opts ...
 		args = append(args, c.dir)
 	}
 
-	return tf.buildTerraformCmd(ctx, nil, args...), nil
+	return tf.buildTerraformCmd(nil, args...), nil
 }

--- a/tfexec/get.go
+++ b/tfexec/get.go
@@ -48,5 +48,5 @@ func (tf *Terraform) getCmd(ctx context.Context, opts ...GetCmdOption) (*exec.Cm
 		args = append(args, c.dir)
 	}
 
-	return tf.buildTerraformCmd(ctx, nil, args...), nil
+	return tf.buildTerraformCmd(nil, args...), nil
 }

--- a/tfexec/graph.go
+++ b/tfexec/graph.go
@@ -81,5 +81,5 @@ func (tf *Terraform) graphCmd(ctx context.Context, opts ...GraphOption) (*exec.C
 		args = append(args, "-type="+c.graphType)
 	}
 
-	return tf.buildTerraformCmd(ctx, nil, args...), nil
+	return tf.buildTerraformCmd(nil, args...), nil
 }

--- a/tfexec/import.go
+++ b/tfexec/import.go
@@ -137,5 +137,5 @@ func (tf *Terraform) importCmd(ctx context.Context, address, id string, opts ...
 		mergeEnv[reattachEnvVar] = reattachStr
 	}
 
-	return tf.buildTerraformCmd(ctx, mergeEnv, args...), nil
+	return tf.buildTerraformCmd(mergeEnv, args...), nil
 }

--- a/tfexec/init.go
+++ b/tfexec/init.go
@@ -183,5 +183,5 @@ func (tf *Terraform) initCmd(ctx context.Context, opts ...InitOption) (*exec.Cmd
 		mergeEnv[reattachEnvVar] = reattachStr
 	}
 
-	return tf.buildTerraformCmd(ctx, mergeEnv, args...), nil
+	return tf.buildTerraformCmd(mergeEnv, args...), nil
 }

--- a/tfexec/internal/e2etest/graceful_termination_linux_test.go
+++ b/tfexec/internal/e2etest/graceful_termination_linux_test.go
@@ -36,8 +36,8 @@ func Test_gracefulTerminationRunTerraformCmd_linux(t *testing.T) {
 			t.Log(err)
 		}
 		output := bufStderr.String() + bufStdout.String()
+		t.Log(output)
 		if !strings.Contains(output, "Gracefully shutting down...") {
-			t.Log(output)
 			t.Fatal("canceling context should gracefully shut terraform down")
 		}
 	})
@@ -68,8 +68,8 @@ func Test_gracefulTerminationRunTerraformCmdWithNoGracefulShutdownTimeout_linux(
 			t.Log(err)
 		}
 		output := bufStderr.String() + bufStdout.String()
+		t.Log(output)
 		if strings.Contains(output, "Gracefully shutting down...") {
-			t.Log(output)
 			t.Fatal("canceling context with no graceful shutdown timeout should immediately kill the process and not start a graceful cancellation")
 		}
 	})

--- a/tfexec/internal/e2etest/graceful_termination_linux_test.go
+++ b/tfexec/internal/e2etest/graceful_termination_linux_test.go
@@ -1,0 +1,45 @@
+package e2etest
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform-exec/tfexec"
+	"github.com/hashicorp/terraform-exec/tfexec/internal/testutil"
+)
+
+func Test_gracefulTerminationRunTerraformCmd_linux(t *testing.T) {
+	runTestVersions(t, []string{testutil.Latest_v1_1}, "infinite_loop", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+		var bufStdout bytes.Buffer
+		var bufStderr bytes.Buffer
+		tf.SetStderr(&bufStdout)
+		tf.SetStdout(&bufStderr)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		err := tf.Init(context.Background())
+		if err != nil {
+			t.Fatalf("error running Init in test directory: %s", err)
+		}
+		doneCh := make(chan error)
+		go func() {
+			doneCh <- tf.Apply(ctx)
+		}()
+		time.Sleep(3 * time.Second)
+		cancel()
+		err = <-doneCh
+		close(doneCh)
+		if err != nil {
+			t.Log(err)
+		}
+		output := bufStderr.String() + bufStdout.String()
+		if !strings.Contains(output, "Gracefully shutting down...") {
+			t.Log(output)
+			t.Fatal("canceling context should gracefully shut terraform down")
+		}
+	})
+
+}

--- a/tfexec/internal/e2etest/testdata/infinite_loop/main.tf
+++ b/tfexec/internal/e2etest/testdata/infinite_loop/main.tf
@@ -1,0 +1,8 @@
+resource "null_resource" "example1" {
+  triggers = {
+    always_run = "${timestamp()}"
+  }
+  provisioner "local-exec" {
+    command = " while true; do echo 'Hit CTRL+C'; sleep 1; done"
+  }
+}

--- a/tfexec/options.go
+++ b/tfexec/options.go
@@ -2,6 +2,7 @@ package tfexec
 
 import (
 	"encoding/json"
+	"time"
 )
 
 // AllowMissingConfigOption represents the -allow-missing-config flag.
@@ -229,6 +230,14 @@ type ParallelismOption struct {
 
 func Parallelism(n int) *ParallelismOption {
 	return &ParallelismOption{n}
+}
+
+type GracefulShutdownTimeoutOption struct {
+	timeout time.Duration
+}
+
+func GracefulShutdownTimeout(timeout time.Duration) *GracefulShutdownTimeoutOption {
+	return &GracefulShutdownTimeoutOption{timeout}
 }
 
 type GraphPlanOption struct {

--- a/tfexec/output.go
+++ b/tfexec/output.go
@@ -59,5 +59,5 @@ func (tf *Terraform) outputCmd(ctx context.Context, opts ...OutputOption) *exec.
 		args = append(args, "-state="+c.state)
 	}
 
-	return tf.buildTerraformCmd(ctx, nil, args...)
+	return tf.buildTerraformCmd(nil, args...)
 }

--- a/tfexec/plan.go
+++ b/tfexec/plan.go
@@ -176,5 +176,5 @@ func (tf *Terraform) planCmd(ctx context.Context, opts ...PlanOption) (*exec.Cmd
 		mergeEnv[reattachEnvVar] = reattachStr
 	}
 
-	return tf.buildTerraformCmd(ctx, mergeEnv, args...), nil
+	return tf.buildTerraformCmd(mergeEnv, args...), nil
 }

--- a/tfexec/providers_lock.go
+++ b/tfexec/providers_lock.go
@@ -78,5 +78,5 @@ func (tf *Terraform) providersLockCmd(ctx context.Context, opts ...ProvidersLock
 		args = append(args, p)
 	}
 
-	return tf.buildTerraformCmd(ctx, nil, args...)
+	return tf.buildTerraformCmd(nil, args...)
 }

--- a/tfexec/providers_schema.go
+++ b/tfexec/providers_schema.go
@@ -29,5 +29,5 @@ func (tf *Terraform) providersSchemaCmd(ctx context.Context, args ...string) *ex
 	allArgs := []string{"providers", "schema", "-json", "-no-color"}
 	allArgs = append(allArgs, args...)
 
-	return tf.buildTerraformCmd(ctx, nil, allArgs...)
+	return tf.buildTerraformCmd(nil, allArgs...)
 }

--- a/tfexec/refresh.go
+++ b/tfexec/refresh.go
@@ -133,5 +133,5 @@ func (tf *Terraform) refreshCmd(ctx context.Context, opts ...RefreshCmdOption) (
 		mergeEnv[reattachEnvVar] = reattachStr
 	}
 
-	return tf.buildTerraformCmd(ctx, mergeEnv, args...), nil
+	return tf.buildTerraformCmd(mergeEnv, args...), nil
 }

--- a/tfexec/show.go
+++ b/tfexec/show.go
@@ -192,5 +192,5 @@ func (tf *Terraform) showCmd(ctx context.Context, jsonOutput bool, mergeEnv map[
 	allArgs = append(allArgs, "-no-color")
 	allArgs = append(allArgs, args...)
 
-	return tf.buildTerraformCmd(ctx, mergeEnv, allArgs...)
+	return tf.buildTerraformCmd(mergeEnv, allArgs...)
 }

--- a/tfexec/state_mv.go
+++ b/tfexec/state_mv.go
@@ -101,5 +101,5 @@ func (tf *Terraform) stateMvCmd(ctx context.Context, source string, destination 
 	args = append(args, source)
 	args = append(args, destination)
 
-	return tf.buildTerraformCmd(ctx, nil, args...), nil
+	return tf.buildTerraformCmd(nil, args...), nil
 }

--- a/tfexec/state_pull.go
+++ b/tfexec/state_pull.go
@@ -51,5 +51,5 @@ func (tf *Terraform) StatePull(ctx context.Context, opts ...StatePullOption) (st
 func (tf *Terraform) statePullCmd(ctx context.Context, mergeEnv map[string]string) *exec.Cmd {
 	args := []string{"state", "pull"}
 
-	return tf.buildTerraformCmd(ctx, mergeEnv, args...)
+	return tf.buildTerraformCmd(mergeEnv, args...)
 }

--- a/tfexec/state_push.go
+++ b/tfexec/state_push.go
@@ -63,5 +63,5 @@ func (tf *Terraform) statePushCmd(ctx context.Context, path string, opts ...Stat
 
 	args = append(args, path)
 
-	return tf.buildTerraformCmd(ctx, nil, args...), nil
+	return tf.buildTerraformCmd(nil, args...), nil
 }

--- a/tfexec/state_rm.go
+++ b/tfexec/state_rm.go
@@ -100,5 +100,5 @@ func (tf *Terraform) stateRmCmd(ctx context.Context, address string, opts ...Sta
 	// positional arguments
 	args = append(args, address)
 
-	return tf.buildTerraformCmd(ctx, nil, args...), nil
+	return tf.buildTerraformCmd(nil, args...), nil
 }

--- a/tfexec/taint.go
+++ b/tfexec/taint.go
@@ -74,5 +74,5 @@ func (tf *Terraform) taintCmd(ctx context.Context, address string, opts ...Taint
 	}
 	args = append(args, address)
 
-	return tf.buildTerraformCmd(ctx, nil, args...)
+	return tf.buildTerraformCmd(nil, args...)
 }

--- a/tfexec/untaint.go
+++ b/tfexec/untaint.go
@@ -74,5 +74,5 @@ func (tf *Terraform) untaintCmd(ctx context.Context, address string, opts ...Unt
 	}
 	args = append(args, address)
 
-	return tf.buildTerraformCmd(ctx, nil, args...)
+	return tf.buildTerraformCmd(nil, args...)
 }

--- a/tfexec/upgrade012.go
+++ b/tfexec/upgrade012.go
@@ -76,5 +76,5 @@ func (tf *Terraform) upgrade012Cmd(ctx context.Context, opts ...Upgrade012Option
 		mergeEnv[reattachEnvVar] = reattachStr
 	}
 
-	return tf.buildTerraformCmd(ctx, mergeEnv, args...), nil
+	return tf.buildTerraformCmd(mergeEnv, args...), nil
 }

--- a/tfexec/upgrade013.go
+++ b/tfexec/upgrade013.go
@@ -64,5 +64,5 @@ func (tf *Terraform) upgrade013Cmd(ctx context.Context, opts ...Upgrade013Option
 		mergeEnv[reattachEnvVar] = reattachStr
 	}
 
-	return tf.buildTerraformCmd(ctx, mergeEnv, args...), nil
+	return tf.buildTerraformCmd(mergeEnv, args...), nil
 }

--- a/tfexec/validate.go
+++ b/tfexec/validate.go
@@ -17,7 +17,7 @@ func (tf *Terraform) Validate(ctx context.Context) (*tfjson.ValidateOutput, erro
 		return nil, fmt.Errorf("terraform validate -json was added in 0.12.0: %w", err)
 	}
 
-	cmd := tf.buildTerraformCmd(ctx, nil, "validate", "-no-color", "-json")
+	cmd := tf.buildTerraformCmd(nil, "validate", "-no-color", "-json")
 
 	var outBuf = bytes.Buffer{}
 	cmd.Stdout = &outBuf

--- a/tfexec/version.go
+++ b/tfexec/version.go
@@ -47,7 +47,7 @@ func (tf *Terraform) Version(ctx context.Context, skipCache bool) (tfVersion *ve
 
 // version does not use the locking on the Terraform instance and should probably not be used directly, prefer Version.
 func (tf *Terraform) version(ctx context.Context) (*version.Version, map[string]*version.Version, error) {
-	versionCmd := tf.buildTerraformCmd(ctx, nil, "version", "-json")
+	versionCmd := tf.buildTerraformCmd(nil, "version", "-json")
 
 	var outBuf bytes.Buffer
 	versionCmd.Stdout = &outBuf
@@ -93,7 +93,7 @@ func parseJsonVersionOutput(stdout []byte) (*version.Version, map[string]*versio
 }
 
 func (tf *Terraform) versionFromPlaintext(ctx context.Context) (*version.Version, map[string]*version.Version, error) {
-	versionCmd := tf.buildTerraformCmd(ctx, nil, "version")
+	versionCmd := tf.buildTerraformCmd(nil, "version")
 
 	var outBuf strings.Builder
 	versionCmd.Stdout = &outBuf

--- a/tfexec/workspace_delete.go
+++ b/tfexec/workspace_delete.go
@@ -75,7 +75,7 @@ func (tf *Terraform) workspaceDeleteCmd(ctx context.Context, workspace string, o
 
 	args = append(args, workspace)
 
-	cmd := tf.buildTerraformCmd(ctx, nil, args...)
+	cmd := tf.buildTerraformCmd(nil, args...)
 
 	return cmd, nil
 }

--- a/tfexec/workspace_list.go
+++ b/tfexec/workspace_list.go
@@ -8,7 +8,7 @@ import (
 // WorkspaceList represents the workspace list subcommand to the Terraform CLI.
 func (tf *Terraform) WorkspaceList(ctx context.Context) ([]string, string, error) {
 	// TODO: [DIR] param option
-	wlCmd := tf.buildTerraformCmd(ctx, nil, "workspace", "list", "-no-color")
+	wlCmd := tf.buildTerraformCmd(nil, "workspace", "list", "-no-color")
 
 	var outBuf strings.Builder
 	wlCmd.Stdout = &outBuf

--- a/tfexec/workspace_new.go
+++ b/tfexec/workspace_new.go
@@ -77,7 +77,7 @@ func (tf *Terraform) workspaceNewCmd(ctx context.Context, workspace string, opts
 
 	args = append(args, workspace)
 
-	cmd := tf.buildTerraformCmd(ctx, nil, args...)
+	cmd := tf.buildTerraformCmd(nil, args...)
 
 	return cmd, nil
 }

--- a/tfexec/workspace_select.go
+++ b/tfexec/workspace_select.go
@@ -6,5 +6,5 @@ import "context"
 func (tf *Terraform) WorkspaceSelect(ctx context.Context, workspace string) error {
 	// TODO: [DIR] param option
 
-	return tf.runTerraformCmd(ctx, tf.buildTerraformCmd(ctx, nil, "workspace", "select", "-no-color", workspace))
+	return tf.runTerraformCmd(ctx, tf.buildTerraformCmd(nil, "workspace", "select", "-no-color", workspace))
 }

--- a/tfexec/workspace_show.go
+++ b/tfexec/workspace_show.go
@@ -31,5 +31,5 @@ func (tf *Terraform) workspaceShowCmd(ctx context.Context) (*exec.Cmd, error) {
 		return nil, fmt.Errorf("workspace show was first introduced in Terraform 0.10.0: %w", err)
 	}
 
-	return tf.buildTerraformCmd(ctx, nil, "workspace", "show", "-no-color"), nil
+	return tf.buildTerraformCmd(nil, "workspace", "show", "-no-color"), nil
 }


### PR DESCRIPTION
This PR adds support for graceful cancellation and a `GracefulShutdownTimeout` option for apply and destroy commands.

Currently when the context is cancelled a SIGKILL is sent to Terraform. This is the default behaviour of `exec.CommandContext` . The SIGKILL forcefully kills the Terraform process and therefore it doesn’t start a graceful shutdown which sometimes ends up with the state lock not being released.

The proposed fix is that on context cancellation, a SIGINT is sent so that Terraform starts a graceful shutdown with the hope of releasing the lock and allowing providers to gracefully terminate, and then, after `GracefulShutdownTimeout` if the command hasn’t finished, then a SIGKILL is sent to forcefully terminate the process.

---

When a command is started, the command that is created is run without a context (equivalent to passing `context.Background()`), and in a concurrent go routine the cancellation of the parent context is monitored.

When the parent context is cancelled, a SIGINT is sent to the command. After `GracefulShutdownTimeout` passes, if the command hasn't finished, a SIGKILL is sent to the command to forcefully kill it.

The `GracefulShutdownTimeout` is also useful so that the caller of tf-exec is able to configure for how long it's willing to wait for the cancellation, which depends on how each provider handles cancellations.


## Refs

- https://github.com/hashicorp/terraform-plugin-sdk/issues/141
- https://github.com/hashicorp/terraform-provider-aws/issues/4177
- https://github.com/hashicorp/terraform-provider-aws/issues/15090
