### PR TITLE
Add support to remove multiple addresses from state

### DIFF
--- a/tfexec/state_rm.go
+++ b/tfexec/state_rm.go
@@ -56,14 +56,19 @@ func (opt *StateOutOption) configureStateRm(conf *stateRmConfig) {
 
 // StateRm represents the terraform state rm subcommand.
 func (tf *Terraform) StateRm(ctx context.Context, address string, opts ...StateRmCmdOption) error {
-	cmd, err := tf.stateRmCmd(ctx, address, opts...)
+	return tf.StateRmAll(ctx, []string{address}, opts...)
+}
+
+// StateRmAll represents the terraform state rm subcommand with multiple addresses
+func (tf *Terraform) StateRmAll(ctx context.Context, addresses []string, opts ...StateRmCmdOption) error {
+	cmd, err := tf.stateRmCmd(ctx, addresses, opts...)
 	if err != nil {
 		return err
 	}
 	return tf.runTerraformCmd(ctx, cmd)
 }
 
-func (tf *Terraform) stateRmCmd(ctx context.Context, address string, opts ...StateRmCmdOption) (*exec.Cmd, error) {
+func (tf *Terraform) stateRmCmd(ctx context.Context, addresses []string, opts ...StateRmCmdOption) (*exec.Cmd, error) {
 	c := defaultStateRmOptions
 
 	for _, o := range opts {
@@ -98,7 +103,7 @@ func (tf *Terraform) stateRmCmd(ctx context.Context, address string, opts ...Sta
 	}
 
 	// positional arguments
-	args = append(args, address)
+	args = append(args, addresses...)
 
 	return tf.buildTerraformCmd(ctx, nil, args...), nil
 }

--- a/tfexec/state_rm_test.go
+++ b/tfexec/state_rm_test.go
@@ -19,7 +19,7 @@ func TestStateRmCmd(t *testing.T) {
 	tf.SetEnv(map[string]string{})
 
 	t.Run("defaults", func(t *testing.T) {
-		stateRmCmd, err := tf.stateRmCmd(context.Background(), "testAddress")
+		stateRmCmd, err := tf.stateRmCmd(context.Background(), []string{"testAddress"})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -34,8 +34,25 @@ func TestStateRmCmd(t *testing.T) {
 		}, nil, stateRmCmd)
 	})
 
+	t.Run("multiple addresses", func(t *testing.T) {
+		stateRmCmd, err := tf.stateRmCmd(context.Background(), []string{"resource.A", "resource.B"})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assertCmd(t, []string{
+			"state",
+			"rm",
+			"-no-color",
+			"-lock-timeout=0s",
+			"-lock=true",
+			"resource.A",
+			"resource.B",
+		}, nil, stateRmCmd)
+	})
+
 	t.Run("override all defaults", func(t *testing.T) {
-		stateRmCmd, err := tf.stateRmCmd(context.Background(), "testAddress", Backup("testbackup"), BackupOut("testbackupout"), LockTimeout("200s"), State("teststate"), StateOut("teststateout"), Lock(false))
+		stateRmCmd, err := tf.stateRmCmd(context.Background(), []string{"testAddress"}, Backup("testbackup"), BackupOut("testbackupout"), LockTimeout("200s"), State("teststate"), StateOut("teststateout"), Lock(false))
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
StateRm is great, but when you have to delete multiple addresses this is super slow

as `terraform state rm` supports multiple addresses, so should this wrapper.

For backwards compatibility I've kept `StateRm` and introduced a new `StateRmAll` method.
