### PR TITLE
gofmt all the things!

### DIFF
--- a/tfexec/exit_errors.go
+++ b/tfexec/exit_errors.go
@@ -271,7 +271,8 @@ func (e *ErrLockIdInvalid) Error() string {
 
 // ErrCLIUsage is returned when the combination of flags or arguments is incorrect.
 //
-//  CLI indicates usage errors in three different ways: either
+//	CLI indicates usage errors in three different ways: either
+//
 // 1. Exit 1, with a custom error message on stderr.
 // 2. Exit 1, with command usage logged to stderr.
 // 3. Exit 127, with command usage logged to stdout.

--- a/tfexec/terraform.go
+++ b/tfexec/terraform.go
@@ -32,14 +32,14 @@ type printfer interface {
 // but it ignores certain environment variables that are managed within the code and prohibits
 // setting them through SetEnv:
 //
-//  - TF_APPEND_USER_AGENT
-//  - TF_IN_AUTOMATION
-//  - TF_INPUT
-//  - TF_LOG
-//  - TF_LOG_PATH
-//  - TF_REATTACH_PROVIDERS
-//  - TF_DISABLE_PLUGIN_TLS
-//  - TF_SKIP_PROVIDER_VERIFY
+//   - TF_APPEND_USER_AGENT
+//   - TF_IN_AUTOMATION
+//   - TF_INPUT
+//   - TF_LOG
+//   - TF_LOG_PATH
+//   - TF_REATTACH_PROVIDERS
+//   - TF_DISABLE_PLUGIN_TLS
+//   - TF_SKIP_PROVIDER_VERIFY
 type Terraform struct {
 	execPath           string
 	workingDir         string


### PR DESCRIPTION
![76v1rw](https://user-images.githubusercontent.com/287584/211369126-cb0e9bd4-3024-4c9c-8bc2-27e341a4cf85.jpg)

Result of `go fmt ./...` with more recent Go version (1.19)

This is in preparation for CI changes which involve bumping Go.
