### PR TITLE
ci: (re)enable releasing via GitHub Action workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: Release
+
+permissions:
+  contents: write # for modifying version in-place & pushing tags
+  packages: read # for downloading signore docker image
+
+on:
+  workflow_dispatch:
+
+env:
+  GOPROXY: https://proxy.golang.org/
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # https://github.com/actions/checkout/releases/tag/v3.2.0
+      -
+        name: Set up Go
+        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # https://github.com/actions/setup-go/releases/tag/v3.5.0
+        with:
+          go-version: stable
+      -
+        id: setup-signore-package
+        uses: hashicorp/setup-signore-package@v1
+      -
+        name: Run release script
+        env:
+          SIGNORE_CLIENT_ID: ${{ secrets.SIGNORE_CLIENT_ID }}
+          SIGNORE_CLIENT_SECRET: ${{ secrets.SIGNORE_CLIENT_SECRET }}
+          SIGNORE_SIGNER: ${{ secrets.SIGNORE_SIGNER }}
+        run: ./scripts/release/release.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,16 @@ The `github.com/hashicorp/terraform-exec` Go module in its entirety is versioned
 
 ## Releases
 
-Releases are made on a reasonably regular basis by the Terraform team, using our custom CI workflows. There is currently no set release schedule and no requirement for contributors to write CHANGELOG entries.
+Releases are made on a reasonably regular basis by the Terraform team, using our custom CI workflows. There is currently no set release schedule and no requirement for _contributors_ to write CHANGELOG entries.
+
+The following notes are only relevant to maintainers.
+
+1. Make sure [CHANGELOG.md](https://github.com/hashicorp/terraform-exec/blob/main/CHANGELOG.md) has all **changes** and the first line has the **version** you're intending to release (with ` (Unreleased)` suffix).
+1. Trigger the [`release` workflow](https://github.com/hashicorp/terraform-exec/actions/workflows/release.yml) from GitHub UI. This will run the [release script](https://github.com/hashicorp/terraform-exec/blob/main/scripts/release/release.sh). As part of that script:
+  - `Unreleased`, `[GH-XXX]` will be replaced.
+  - The [version](https://github.com/hashicorp/terraform-exec/blob/main/internal/version/version.go#L3) will be bumped to match the one parsed from `CHANGELOG.md`.
+  - Tag will be pushed
+1. [Create new release](https://github.com/hashicorp/terraform-exec/releases/new) via GitHub UI to point to the new tag and copy the appropriate part of the CHANGELOG.md there.
 
 ## Security vulnerabilities
 

--- a/scripts/release/release.sh
+++ b/scripts/release/release.sh
@@ -21,11 +21,9 @@ function init {
   DATE=$(date '+%B %d, %Y')
 
   if [ "$CI" = true ] ; then
-    GPG_KEY_ID=C6DC8F8C8E78B36A
-    gpg --batch --import <(echo -e "${GPG_PUBLIC_KEY}")
-    gpg --batch --import <(echo -e "${GPG_PRIVATE_KEY}")
-    git config --global user.email hashibot-feedback+tf-sdk-circleci@hashicorp.com
-    git config --global user.name "Terraform SDK CircleCI"
+    git config --global user.email "proj-terraform-exec@hashicorp.com"
+    git config --global user.name "terraform-exec [bot]"
+    git config --global gpg.program scripts/release/signore-wrapper.sh
   fi
 
   TARGET_VERSION="$(getTargetVersion)"
@@ -67,8 +65,8 @@ function commitChanges {
   git add internal/version/version.go
 
   if [ "$CI" = true ] ; then
-      git commit --gpg-sign="${GPG_KEY_ID}" -m "v${TARGET_VERSION} [skip ci]"
-      git tag -a -m "v${TARGET_VERSION}" -s -u "${GPG_KEY_ID}" "v${TARGET_VERSION}"
+      git commit --gpg-sign="${SIGNORE_SIGNER}" -m "v${TARGET_VERSION} [skip ci]"
+      git tag -a -m "v${TARGET_VERSION}" -s -u "${SIGNORE_SIGNER}" "v${TARGET_VERSION}"
   else
       git commit -m "v${TARGET_VERSION} [skip ci]"
       git tag -a -m "v${TARGET_VERSION}" -s "v${TARGET_VERSION}"

--- a/scripts/release/signore-wrapper.sh
+++ b/scripts/release/signore-wrapper.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+printf '\n[GNUPG:] SIG_CREATED ' >&${1#--status-fd=}
+signore sign --file /dev/stdin --signer $3 2>/dev/null


### PR DESCRIPTION
This follows a guide in https://github.com/hashicorp/signore/blob/main/docs/SIGNING_GIT_COMMITS.md and https://github.com/hashicorp/signore/blob/main/docs/SIGNING_IN_CI.md

## TODO

 - [x] register new bot GitHub account for holding new GPG key
 - [x] update script to use new email
 - [x] get a new signore signer
 - [x] upload new pubkey to the bot GitHub account
 - [x] ensure the correct `SIGNORE_SIGNER` is set
 - [x] ensure the correct `SIGNORE_CLIENT` & `SIGNORE_SECRET` are set
 - [x] Add release instructions to CONTRIBUTING.md