### PR TITLE
Add support for `metadata functions -json` command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 dist
+go.work*

--- a/tfexec/internal/e2etest/metadata_functions_test.go
+++ b/tfexec/internal/e2etest/metadata_functions_test.go
@@ -1,0 +1,23 @@
+package e2etest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/go-version"
+
+	"github.com/hashicorp/terraform-exec/tfexec"
+)
+
+func TestMetadataFunctions(t *testing.T) {
+	runTest(t, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+		if tfv.LessThan(metadataFunctionsMinVersion) {
+			t.Skip("metadata functions command is not available in this Terraform version")
+		}
+
+		_, err := tf.MetadataFunctions(context.Background())
+		if err != nil {
+			t.Fatalf("error running MetadataFunctions: %s", err)
+		}
+	})
+}

--- a/tfexec/internal/e2etest/util_test.go
+++ b/tfexec/internal/e2etest/util_test.go
@@ -24,6 +24,8 @@ var (
 	showMinVersion = version.Must(version.NewVersion("0.12.0"))
 
 	providerAddressMinVersion = version.Must(version.NewVersion("0.13.0"))
+
+	metadataFunctionsMinVersion = version.Must(version.NewVersion("1.4.0"))
 )
 
 func runTest(t *testing.T, fixtureName string, cb func(t *testing.T, tfVersion *version.Version, tf *tfexec.Terraform)) {

--- a/tfexec/metadata_functions.go
+++ b/tfexec/metadata_functions.go
@@ -1,0 +1,39 @@
+package tfexec
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+
+	tfjson "github.com/hashicorp/terraform-json"
+)
+
+// MetadataFunctions represents the terraform metadata functions -json subcommand.
+func (tf *Terraform) MetadataFunctions(ctx context.Context) (*tfjson.MetadataFunctions, error) {
+	err := tf.compatible(ctx, tf1_4_0, nil)
+	if err != nil {
+		return nil, fmt.Errorf("terraform metadata functions was added in 1.4.0: %w", err)
+	}
+
+	functionsCmd := tf.metadataFunctionsCmd(ctx)
+
+	var ret tfjson.MetadataFunctions
+	err = tf.runTerraformCmdJSON(ctx, functionsCmd, &ret)
+	if err != nil {
+		return nil, err
+	}
+
+	err = ret.Validate()
+	if err != nil {
+		return nil, err
+	}
+
+	return &ret, nil
+}
+
+func (tf *Terraform) metadataFunctionsCmd(ctx context.Context, args ...string) *exec.Cmd {
+	allArgs := []string{"metadata", "functions", "-json"}
+	allArgs = append(allArgs, args...)
+
+	return tf.buildTerraformCmd(ctx, nil, allArgs...)
+}

--- a/tfexec/metadata_functions.go
+++ b/tfexec/metadata_functions.go
@@ -23,7 +23,6 @@ func (tf *Terraform) MetadataFunctions(ctx context.Context) (*tfjson.MetadataFun
 		return nil, err
 	}
 
-
 	return &ret, nil
 }
 

--- a/tfexec/metadata_functions.go
+++ b/tfexec/metadata_functions.go
@@ -23,10 +23,6 @@ func (tf *Terraform) MetadataFunctions(ctx context.Context) (*tfjson.MetadataFun
 		return nil, err
 	}
 
-	err = ret.Validate()
-	if err != nil {
-		return nil, err
-	}
 
 	return &ret, nil
 }

--- a/tfexec/metadata_functions_test.go
+++ b/tfexec/metadata_functions_test.go
@@ -1,0 +1,29 @@
+package tfexec
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-exec/tfexec/internal/testutil"
+)
+
+func TestMetadataFunctionsCmd(t *testing.T) {
+	td := t.TempDir()
+
+	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest_v1_1))
+	// tf, err := NewTerraform(td, tfVersion(t, testutil.Latest_v1_4)) // TODO! enable after 1.4 release
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// empty env, to avoid environ mismatch in testing
+	tf.SetEnv(map[string]string{})
+
+	functionsCmd := tf.metadataFunctionsCmd(context.Background())
+
+	assertCmd(t, []string{
+		"metadata",
+		"functions",
+		"-json",
+	}, nil, functionsCmd)
+}

--- a/tfexec/version.go
+++ b/tfexec/version.go
@@ -27,6 +27,7 @@ var (
 	tf0_15_2 = version.Must(version.NewVersion("0.15.2"))
 	tf0_15_3 = version.Must(version.NewVersion("0.15.3"))
 	tf1_1_0  = version.Must(version.NewVersion("1.1.0"))
+	tf1_4_0  = version.Must(version.NewVersion("1.4.0"))
 )
 
 // Version returns structured output from the terraform version command including both the Terraform CLI version


### PR DESCRIPTION
This PR adds support for the new `terraform metadata functions -json` command, which was introduced in https://github.com/hashicorp/terraform/pull/32487. We need this to obtain the function signatures within terraform-ls.

Depends on:
* https://github.com/hashicorp/terraform-json/pull/68 

## TODO

- [x] Bump terraform-json version after it was released
- [x] Add an E2E test? ~~That might require the Terraform 1.4 release~~ It's working for `main` https://github.com/hashicorp/terraform-exec/actions/runs/4176231939/jobs/7232445810#step:4:910