### PR TITLE
fix issues with version-specific tests when run against a local binary

### DIFF
--- a/tfexec/internal/e2etest/apply_test.go
+++ b/tfexec/internal/e2etest/apply_test.go
@@ -29,7 +29,7 @@ func TestApply(t *testing.T) {
 func TestApplyJSON_TF014AndEarlier(t *testing.T) {
 	versions := []string{testutil.Latest011, testutil.Latest012, testutil.Latest013, testutil.Latest014}
 
-	runTestWithVersions(t, "basic", versions, func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTestWithVersions(t, versions, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
 		err := tf.Init(context.Background())
 		if err != nil {
 			t.Fatalf("error running Init in test directory: %s", err)
@@ -47,7 +47,7 @@ func TestApplyJSON_TF014AndEarlier(t *testing.T) {
 func TestApplyJSON_TF015AndLater(t *testing.T) {
 	versions := []string{testutil.Latest015, testutil.Latest_v1, testutil.Latest_v1_1}
 
-	runTestWithVersions(t, "basic", versions, func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTestWithVersions(t, versions, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
 		err := tf.Init(context.Background())
 		if err != nil {
 			t.Fatalf("error running Init in test directory: %s", err)

--- a/tfexec/internal/e2etest/destroy_test.go
+++ b/tfexec/internal/e2etest/destroy_test.go
@@ -34,7 +34,7 @@ func TestDestroy(t *testing.T) {
 func TestDestroyJSON_TF014AndEarlier(t *testing.T) {
 	versions := []string{testutil.Latest011, testutil.Latest012, testutil.Latest013, testutil.Latest014}
 
-	runTestWithVersions(t, "basic", versions, func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTestWithVersions(t, versions, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
 		err := tf.Init(context.Background())
 		if err != nil {
 			t.Fatalf("error running Init in test directory: %s", err)
@@ -52,7 +52,7 @@ func TestDestroyJSON_TF014AndEarlier(t *testing.T) {
 func TestDestroyJSON_TF015AndLater(t *testing.T) {
 	versions := []string{testutil.Latest015, testutil.Latest_v1, testutil.Latest_v1_1}
 
-	runTestWithVersions(t, "basic", versions, func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTestWithVersions(t, versions, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
 		err := tf.Init(context.Background())
 		if err != nil {
 			t.Fatalf("error running Init in test directory: %s", err)

--- a/tfexec/internal/e2etest/plan_test.go
+++ b/tfexec/internal/e2etest/plan_test.go
@@ -53,7 +53,7 @@ func TestPlanWithState(t *testing.T) {
 func TestPlanJSON_TF014AndEarlier(t *testing.T) {
 	versions := []string{testutil.Latest011, testutil.Latest012, testutil.Latest013, testutil.Latest014}
 
-	runTestWithVersions(t, "basic", versions, func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTestWithVersions(t, versions, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
 		err := tf.Init(context.Background())
 		if err != nil {
 			t.Fatalf("error running Init in test directory: %s", err)
@@ -74,7 +74,7 @@ func TestPlanJSON_TF014AndEarlier(t *testing.T) {
 func TestPlanJSON_TF015AndLater(t *testing.T) {
 	versions := []string{testutil.Latest015, testutil.Latest_v1, testutil.Latest_v1_1}
 
-	runTestWithVersions(t, "basic", versions, func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTestWithVersions(t, versions, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
 		err := tf.Init(context.Background())
 		if err != nil {
 			t.Fatalf("error running Init in test directory: %s", err)

--- a/tfexec/internal/e2etest/refresh_test.go
+++ b/tfexec/internal/e2etest/refresh_test.go
@@ -34,7 +34,7 @@ func TestRefresh(t *testing.T) {
 func TestRefreshJSON_TF014AndEarlier(t *testing.T) {
 	versions := []string{testutil.Latest011, testutil.Latest012, testutil.Latest013, testutil.Latest014}
 
-	runTestWithVersions(t, "basic", versions, func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTestWithVersions(t, versions, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
 		err := tf.Init(context.Background())
 		if err != nil {
 			t.Fatalf("error running Init in test directory: %s", err)
@@ -52,7 +52,7 @@ func TestRefreshJSON_TF014AndEarlier(t *testing.T) {
 func TestRefreshJSON_TF015AndLater(t *testing.T) {
 	versions := []string{testutil.Latest015, testutil.Latest_v1, testutil.Latest_v1_1}
 
-	runTestWithVersions(t, "basic", versions, func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTestWithVersions(t, versions, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
 		err := tf.Init(context.Background())
 		if err != nil {
 			t.Fatalf("error running Init in test directory: %s", err)

--- a/tfexec/internal/e2etest/show_test.go
+++ b/tfexec/internal/e2etest/show_test.go
@@ -116,7 +116,7 @@ func TestShow_noInitBasic(t *testing.T) {
 	// no providers to download, this is unintended behaviour, as
 	// init is not actually necessary. This is considered a known issue in
 	// pre-1.2.0 versions.
-	runTestVersions(t, []string{testutil.Latest012, testutil.Latest013, testutil.Latest014, testutil.Latest015, testutil.Latest_v1, testutil.Latest_v1_1}, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTestWithVersions(t, []string{testutil.Latest012, testutil.Latest013, testutil.Latest014, testutil.Latest015, testutil.Latest_v1, testutil.Latest_v1_1}, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
 		var noInit *tfexec.ErrNoInit
 		_, err := tf.Show(context.Background())
 		if !errors.As(err, &noInit) {
@@ -154,7 +154,7 @@ func TestShow_noInitModule(t *testing.T) {
 	// no providers to download, this is unintended behaviour, as
 	// init is not actually necessary. This is considered a known issue in
 	// pre-1.2.0 versions.
-	runTestVersions(t, []string{testutil.Latest012, testutil.Latest013, testutil.Latest014, testutil.Latest015, testutil.Latest_v1, testutil.Latest_v1_1}, "registry_module", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTestWithVersions(t, []string{testutil.Latest012, testutil.Latest013, testutil.Latest014, testutil.Latest015, testutil.Latest_v1, testutil.Latest_v1_1}, "registry_module", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
 		var noInit *tfexec.ErrNoInit
 		_, err := tf.Show(context.Background())
 		if !errors.As(err, &noInit) {
@@ -306,7 +306,7 @@ func TestShow_versionMismatch(t *testing.T) {
 // so we maintain one fixture per supported version.
 // See github.com/hashicorp/terraform/25920
 func TestShowStateFile012(t *testing.T) {
-	runTestVersions(t, []string{testutil.Latest012}, "non_default_statefile_012", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTestWithVersions(t, []string{testutil.Latest012}, "non_default_statefile_012", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
 		expected := &tfjson.State{
 			FormatVersion: "0.1",
 			// TerraformVersion is ignored to facilitate latest version testing
@@ -344,7 +344,7 @@ func TestShowStateFile012(t *testing.T) {
 }
 
 func TestShowStateFile013(t *testing.T) {
-	runTestVersions(t, []string{testutil.Latest013, testutil.Latest014}, "non_default_statefile_013", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTestWithVersions(t, []string{testutil.Latest013, testutil.Latest014}, "non_default_statefile_013", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
 		expected := &tfjson.State{
 			FormatVersion: "0.1",
 			// TerraformVersion is ignored to facilitate latest version testing
@@ -382,7 +382,7 @@ func TestShowStateFile013(t *testing.T) {
 }
 
 func TestShowStateFile014(t *testing.T) {
-	runTestVersions(t, []string{testutil.Latest014}, "non_default_statefile_014", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTestWithVersions(t, []string{testutil.Latest014}, "non_default_statefile_014", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
 		expected := &tfjson.State{
 			FormatVersion: "0.1",
 			// TerraformVersion is ignored to facilitate latest version testing
@@ -422,7 +422,7 @@ func TestShowStateFile014(t *testing.T) {
 // Plan files cannot be transferred between different Terraform versions,
 // so we maintain one fixture per supported version
 func TestShowPlanFile012_linux(t *testing.T) {
-	runTestVersions(t, []string{testutil.Latest012}, "non_default_planfile_012", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTestWithVersions(t, []string{testutil.Latest012}, "non_default_planfile_012", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
 		if runtime.GOOS != "linux" {
 			t.Skip("plan file created in 0.12 on Linux is not compatible with other systems")
 		}
@@ -488,7 +488,7 @@ func TestShowPlanFile012_linux(t *testing.T) {
 }
 
 func TestShowPlanFile013(t *testing.T) {
-	runTestVersions(t, []string{testutil.Latest013}, "non_default_planfile_013", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTestWithVersions(t, []string{testutil.Latest013}, "non_default_planfile_013", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
 		providerName := "registry.terraform.io/hashicorp/null"
 
 		expected := &tfjson.Plan{
@@ -550,7 +550,7 @@ func TestShowPlanFile013(t *testing.T) {
 }
 
 func TestShowPlanFile014(t *testing.T) {
-	runTestVersions(t, []string{testutil.Latest014}, "non_default_planfile_014", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTestWithVersions(t, []string{testutil.Latest014}, "non_default_planfile_014", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
 		providerName := "registry.terraform.io/hashicorp/null"
 
 		expected := &tfjson.Plan{
@@ -615,7 +615,7 @@ func TestShowPlanFile014(t *testing.T) {
 }
 
 func TestShowPlanFileRaw012_linux(t *testing.T) {
-	runTestVersions(t, []string{testutil.Latest012}, "non_default_planfile_012", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTestWithVersions(t, []string{testutil.Latest012}, "non_default_planfile_012", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
 		if runtime.GOOS != "linux" {
 			t.Skip("plan file created in 0.12 on Linux is not compatible with other systems")
 		}
@@ -647,7 +647,7 @@ func TestShowPlanFileRaw012_linux(t *testing.T) {
 }
 
 func TestShowPlanFileRaw013(t *testing.T) {
-	runTestVersions(t, []string{testutil.Latest013}, "non_default_planfile_013", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTestWithVersions(t, []string{testutil.Latest013}, "non_default_planfile_013", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
 		f, err := os.Open("testdata/non_default_planfile_013/human_readable_output.txt")
 		if err != nil {
 			t.Fatal(err)
@@ -675,7 +675,7 @@ func TestShowPlanFileRaw013(t *testing.T) {
 }
 
 func TestShowPlanFileRaw014(t *testing.T) {
-	runTestVersions(t, []string{testutil.Latest014}, "non_default_planfile_014", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTestWithVersions(t, []string{testutil.Latest014}, "non_default_planfile_014", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
 		f, err := os.Open("testdata/non_default_planfile_013/human_readable_output.txt")
 		if err != nil {
 			t.Fatal(err)

--- a/tfexec/internal/e2etest/upgrade012_test.go
+++ b/tfexec/internal/e2etest/upgrade012_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestUpgrade012(t *testing.T) {
-	runTestVersions(t, []string{testutil.Latest012}, "pre_011_syntax", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+	runTestWithVersions(t, []string{testutil.Latest012}, "pre_011_syntax", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
 		err := tf.Init(context.Background())
 		if err != nil {
 			t.Fatalf("error running Init in test directory: %s", err)

--- a/tfexec/internal/e2etest/util_test.go
+++ b/tfexec/internal/e2etest/util_test.go
@@ -42,12 +42,6 @@ func runTest(t *testing.T, fixtureName string, cb func(t *testing.T, tfVersion *
 		versions = strings.Split(override, ",")
 	}
 
-	runTestWithVersions(t, fixtureName, versions, cb)
-}
-
-func runTestWithVersions(t *testing.T, fixtureName string, versions []string, cb func(t *testing.T, tfVersion *version.Version, tf *tfexec.Terraform)) {
-	t.Helper()
-
 	// If the env var TFEXEC_E2ETEST_TERRAFORM_PATH is set to the path of a
 	// valid Terraform executable, only tests appropriate to that
 	// executable's version will be run.
@@ -79,10 +73,10 @@ func runTestWithVersions(t *testing.T, fixtureName string, versions []string, cb
 		versions = []string{lVersion.String()}
 	}
 
-	runTestVersions(t, versions, fixtureName, cb)
+	runTestWithVersions(t, versions, fixtureName, cb)
 }
 
-func runTestVersions(t *testing.T, versions []string, fixtureName string, cb func(t *testing.T, tfVersion *version.Version, tf *tfexec.Terraform)) {
+func runTestWithVersions(t *testing.T, versions []string, fixtureName string, cb func(t *testing.T, tfVersion *version.Version, tf *tfexec.Terraform)) {
 	t.Helper()
 
 	alreadyRunVersions := map[string]bool{}


### PR DESCRIPTION
When running e2e tests against a locally built Terraform binary set with `TFEXEC_E2ETEST_TERRAFORM_PATH`, the `runTestWithVersions` helper (introduced in #354) has some surprising behavior: it throws away the list of versions that was passed in and runs the test against the local binary instead. This seems fairly undesirable and was likely not an intended effect of that prior PR, since the tests using that helper are testing version-specific behavior (and thus are prone to fail when a local bin path is set!).

This PR proposes moving that version override behavior into `runTest`, where it was previously, and combining `runTestWithVersions` and `runTestVersions` into one test helper that runs the given test function against _only_ the versions passed in.

Closes https://github.com/hashicorp/terraform/issues/32639

**Potential future enhancement:**

If it would be valuable to have the ability to run some tests against a specified list of versions _as well as_ the local binary if it exists, probably a clearer way to do that would be to add something like a `runTestWithVersionsAndLatest` helper that reads from `TFEXEC_E2ETEST_TERRAFORM_PATH` and appends the local binary's version instead of overwriting the others. 

