### PR TITLE
fix: Update regex to reflect 1.4 error changes

### DIFF
--- a/tfexec/exit_errors.go
+++ b/tfexec/exit_errors.go
@@ -39,7 +39,10 @@ var (
 
 	tfVersionMismatchErrRegexp        = regexp.MustCompile(`Error: The currently running version of Terraform doesn't meet the|Error: Unsupported Terraform Core version`)
 	tfVersionMismatchConstraintRegexp = regexp.MustCompile(`required_version = "(.+)"|Required version: (.+)\b`)
-	configInvalidErrRegexp            = regexp.MustCompile(`There are some problems with the configuration, described below.`)
+	configInvalidErrRegexp            = regexp.MustCompile(
+		`There are some problems with the configuration, described below.|` +
+			`Error: Unsupported block type|Error: Unsupported argument`, // v1.4+
+	)
 
 	stateLockErrRegexp     = regexp.MustCompile(`Error acquiring the state lock`)
 	stateLockInfoRegexp    = regexp.MustCompile(`Lock Info:\n\s*ID:\s*([^\n]+)\n\s*Path:\s*([^\n]+)\n\s*Operation:\s*([^\n]+)\n\s*Who:\s*([^\n]+)\n\s*Version:\s*([^\n]+)\n\s*Created:\s*([^\n]+)\n`)

--- a/tfexec/internal/e2etest/util_test.go
+++ b/tfexec/internal/e2etest/util_test.go
@@ -88,7 +88,7 @@ func runTestVersions(t *testing.T, versions []string, fixtureName string, cb fun
 	alreadyRunVersions := map[string]bool{}
 	for _, tfv := range versions {
 		t.Run(fmt.Sprintf("%s-%s", fixtureName, tfv), func(t *testing.T) {
-			if runtime.GOOS == "darwin" && runtime.GOARCH == "arm64" {
+			if !strings.HasPrefix(tfv, "refs/") && runtime.GOOS == "darwin" && runtime.GOARCH == "arm64" {
 				v, err := version.NewVersion(tfv)
 				if err != nil {
 					t.Fatal(err)


### PR DESCRIPTION
This is to address the nightly E2E test failures we've been seeing for some time now.

We _might_ be able to also address this more holistically as part of https://github.com/hashicorp/terraform-exec/pull/352 but this PR represents much smaller diff and still gets us back to green CI.