### PR TITLE
scripts/release: update env var for GHA

### DIFF
--- a/scripts/release/release.sh
+++ b/scripts/release/release.sh
@@ -72,7 +72,7 @@ function commitChanges {
       git tag -a -m "v${TARGET_VERSION}" -s "v${TARGET_VERSION}"
   fi
 
-  git push origin "${CIRCLE_BRANCH}"
+  git push origin "${GITHUB_REF}"
   git push origin "v${TARGET_VERSION}"
 }
 

--- a/scripts/release/release.sh
+++ b/scripts/release/release.sh
@@ -72,7 +72,7 @@ function commitChanges {
       git tag -a -m "v${TARGET_VERSION}" -s "v${TARGET_VERSION}"
   fi
 
-  git push origin "${GITHUB_REF}"
+  git push origin "${GITHUB_REF_NAME}"
   git push origin "v${TARGET_VERSION}"
 }
 


### PR DESCRIPTION
Note that GHA's `GITHUB_REF` is the whole refspec, not just the branch name, which should still work according to the man page.