### PR TITLE
ci: Use deploy SSH key to push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,8 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # https://github.com/actions/checkout/releases/tag/v3.2.0
+        with:
+          ssh-key: "${{ secrets.GIT_SSH_PRIVATE_KEY }}"
       -
         name: Set up Go
         uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # https://github.com/actions/setup-go/releases/tag/v3.5.0
@@ -31,4 +33,7 @@ jobs:
           SIGNORE_CLIENT_ID: ${{ secrets.SIGNORE_CLIENT_ID }}
           SIGNORE_CLIENT_SECRET: ${{ secrets.SIGNORE_CLIENT_SECRET }}
           SIGNORE_SIGNER: ${{ secrets.SIGNORE_SIGNER }}
-        run: ./scripts/release/release.sh
+        run: |
+          echo "${{ secrets.GIT_SSH_PRIVATE_KEY }}" > ~/.ssh/id_ed22519
+          ./scripts/release/release.sh
+          rm -f ~/.ssh/id_ed22519

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,11 +20,6 @@ jobs:
         with:
           ssh-key: "${{ secrets.GIT_SSH_PRIVATE_KEY }}"
       -
-        name: Set up Go
-        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # https://github.com/actions/setup-go/releases/tag/v3.5.0
-        with:
-          go-version: stable
-      -
         id: setup-signore-package
         uses: hashicorp/setup-signore-package@v1
       -


### PR DESCRIPTION
Since we have branch protection enabled and we need to push new commit as part of the release into the protected branch (`main`), we run into some limitations as far as how this can be handled in GitHub Actions.

 - workflow tokens cannot bypass the branch protection, as per https://github.com/community/community/discussions/13836
 - Deploy keys with write permissions can - as these have similar scope as admin users on the repo as per [official docs](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/managing-deploy-keys#deploy-keys)
   > Deploy keys with write access can perform the same actions as an organization member with admin access, or a collaborator on a personal repository.

I have already generated the deploy key and added to the repo + added the private part as a secret.

This should provide a reasonable balance between convenience and security, since we can easily rotate the deploy key in the context of the repository (rather than under a separate bot GH account) and still keep the key scoped to the repository.
The new time-scoped granular PATs would probably be even more secure, but the rotation workflow seems painfully manual.

Hopefully GitHub will eventually come up with some way of allowing the workflow token to bypass the branch protection and then we will have the best solution where no manual key/token management is needed and the token only has the necessary scope as per `permission` block in the workflow YAML file.