### PR TITLE
ci: add forgotten mkdir to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,7 @@ jobs:
           SIGNORE_CLIENT_SECRET: ${{ secrets.SIGNORE_CLIENT_SECRET }}
           SIGNORE_SIGNER: ${{ secrets.SIGNORE_SIGNER }}
         run: |
+          mkdir -p ~/.ssh
           echo "${{ secrets.GIT_SSH_PRIVATE_KEY }}" > ~/.ssh/id_ed22519
           ./scripts/release/release.sh
           rm -f ~/.ssh/id_ed22519


### PR DESCRIPTION
Should address https://github.com/hashicorp/terraform-exec/actions/runs/4224637608/jobs/7335853270#step:4:20