### PR TITLE
scripts/release: error when version cannot be parsed

### DIFF
--- a/scripts/release/release.sh
+++ b/scripts/release/release.sh
@@ -27,15 +27,18 @@ function init {
   fi
 
   TARGET_VERSION="$(getTargetVersion)"
+
+  if [ "$TARGET_VERSION" = "" ] ; then
+    printf "Target version not found in changelog, exiting\n"
+    exit 1
+  fi
 }
 
 semverRegex='\([0-9]\+\.[0-9]\+\.[0-9]\+\)\(-\?\)\([0-9a-zA-Z.]\+\)\?'
 
 function getTargetVersion {
   # parse target version from CHANGELOG
-  sed -n 's/^# '"$semverRegex"' (Unreleased)$/\1\2\3/p' CHANGELOG.md || \
-     (printf "\nTarget version not found in changelog, exiting" && \
-       exit 1)
+  sed -n 's/^# '"$semverRegex"' (Unreleased)$/\1\2\3/p' CHANGELOG.md
 }
 
 function modifyChangelog {


### PR DESCRIPTION
During the release workflow https://github.com/hashicorp/terraform-exec/actions/runs/4224742942/jobs/7336093882, the target version could not be parsed from the changelog, due to a typo.

The release script should have exited with an error at this point, but instead continued with a blank `TARGET_VERSION`, causing problems down the line.

This PR makes release.sh exit 1 if the version cannot be parsed from the changelog.

The previous behaviour was not explicit due to overuse of subshells. This change makes it more explicit.

### Testing

Tested the behaviour when CHANGELOG.md is valid:

```sh
$ ./scripts/release/release.sh
...
$ echo $?
0
```

Modified CHANGELOG.md so the first line said "unreleased" instead of "Unreleased".

```sh
$ ./scripts/release/release.sh
Target version not found in changelog, exiting
$ echo $?
1
```
