### PR TITLE
bugfix: correctly populate stderr

### DIFF
--- a/tfexec/cmd_default.go
+++ b/tfexec/cmd_default.go
@@ -5,6 +5,7 @@ package tfexec
 
 import (
 	"context"
+	"fmt"
 	"os/exec"
 	"strings"
 	"sync"
@@ -76,15 +77,15 @@ func (tf *Terraform) runTerraformCmd(ctx context.Context, cmd *exec.Cmd) error {
 		}
 	}
 	if err != nil {
-		return err
+		return fmt.Errorf("%w\n%s", err, errBuf.String())
 	}
 
 	// Return error if there was an issue reading the std out/err
 	if errStdout != nil && ctx.Err() != nil {
-		return errStdout
+		return fmt.Errorf("%w\n%s", errStdout, errBuf.String())
 	}
 	if errStderr != nil && ctx.Err() != nil {
-		return errStderr
+		return fmt.Errorf("%w\n%s", errStderr, errBuf.String())
 	}
 
 	return nil

--- a/tfexec/cmd_linux.go
+++ b/tfexec/cmd_linux.go
@@ -2,6 +2,7 @@ package tfexec
 
 import (
 	"context"
+	"fmt"
 	"os/exec"
 	"strings"
 	"sync"
@@ -81,15 +82,15 @@ func (tf *Terraform) runTerraformCmd(ctx context.Context, cmd *exec.Cmd) error {
 		}
 	}
 	if err != nil {
-		return err
+		return fmt.Errorf("%w\n%s", err, errBuf.String())
 	}
 
 	// Return error if there was an issue reading the std out/err
 	if errStdout != nil && ctx.Err() != nil {
-		return errStdout
+		return fmt.Errorf("%w\n%s", errStdout, errBuf.String())
 	}
 	if errStderr != nil && ctx.Err() != nil {
-		return errStderr
+		return fmt.Errorf("%w\n%s", errStderr, errBuf.String())
 	}
 
 	return nil

--- a/tfexec/internal/e2etest/errors_test.go
+++ b/tfexec/internal/e2etest/errors_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"os"
 	"os/exec"
+	"strings"
 	"testing"
 	"time"
 
@@ -107,6 +108,10 @@ func TestLockedState(t *testing.T) {
 		err = tf.Apply(context.Background())
 		if err == nil {
 			t.Fatal("expected error, but didn't find one")
+		}
+
+		if !strings.Contains(err.Error(), "state lock") {
+			t.Fatal("expected err.Error() to contain 'state lock', but it did not")
 		}
 	})
 }


### PR DESCRIPTION
https://github.com/hashicorp/terraform-exec/pull/352 introduced a bug in which stderr from Terraform commands was not included in the error returned from `tf.Apply()`, etc.

This PR fixes this. Note the inclusion of `errBuf` where `tf.wrapExitError()` was used before.

Also add a test step that fails before this change.