### PR TITLE
ci: Add PR test for copyright headers

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,17 @@ env:
   GOPROXY: https://proxy.golang.org/
 
 jobs:
+  copywrite:
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # https://github.com/actions/checkout/releases/tag/v3.5.0
+      - name: Install copywrite
+        uses: hashicorp/setup-copywrite@v1.0.0
+      - name: Validate Header Compliance
+        run: copywrite headers --plan
+
   # resolve-versions allows us to show resolved Go versions in job titles
   # for added clarity and quick orientation in a long list of past jobs
   resolve-versions:


### PR DESCRIPTION
Depends on
 - https://github.com/hashicorp/terraform-exec/pull/378
 - https://github.com/hashicorp/terraform-exec/pull/357

--- 

This is a follow-up to https://github.com/hashicorp/terraform-exec/pull/357 to ensure we don't introduce new files with missing copyright headers and keep the repository compliant.
