### PR TITLE
remove workspace env var and not set it to an empty string.

### DIFF
--- a/tfexec/cmd.go
+++ b/tfexec/cmd.go
@@ -169,7 +169,7 @@ func (tf *Terraform) buildEnv(mergeEnv map[string]string) []string {
 	env[automationEnvVar] = "1"
 
 	// force usage of workspace methods for switching
-	env[workspaceEnvVar] = ""
+	delete(env, workspaceEnvVar)
 
 	if tf.disablePluginTLS {
 		env[disablePluginTLSEnvVar] = "1"

--- a/tfexec/cmd_test.go
+++ b/tfexec/cmd_test.go
@@ -46,7 +46,6 @@ func defaultEnv() []string {
 		"TF_LOG_CORE=",
 		"TF_LOG_PATH=",
 		"TF_LOG_PROVIDER=",
-		"TF_WORKSPACE=",
 	}
 }
 


### PR DESCRIPTION
Setting the environment variable to an empty string confuses the terraform binary as seen below:

```
TF_WORKSPACE= terraform init -no-color -input=false -get=false -upgrade=false -backend=false

Error: Terraform Cloud returned an unexpected error

invalid value for workspace
```

With this patch the `TF_WORKSPACE` will not exist and avoids the above problem. I have tested this locally with terraform 1.4.5 and it works.