### PR TITLE
feat: add refresh-only flag for plan and apply methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ BUG FIXES:
 
  - Fix bug in which the `TF_WORKSPACE` env var was set to an empty string, instead of being unset as intended. [GH-388]
 
+ENHANCEMENTS:
+
+- tfexec: Add `-refresh-only` to `(Terraform).Apply()` and `(Terraform).Plan()` methods ([#402](https://github.com/hashicorp/terraform-exec/pull/402))
+
 # 0.18.1 (March 01, 2023)
 
 BUG FIXES:

--- a/tfexec/apply_test.go
+++ b/tfexec/apply_test.go
@@ -67,6 +67,26 @@ func TestApplyCmd(t *testing.T) {
 			"testfile",
 		}, nil, applyCmd)
 	})
+
+	t.Run("refresh-only operation", func(t *testing.T) {
+		applyCmd, err := tf.applyCmd(context.Background(),
+			RefreshOnly(true),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assertCmd(t, []string{
+			"apply",
+			"-no-color",
+			"-auto-approve",
+			"-input=false",
+			"-lock=true",
+			"-parallelism=10",
+			"-refresh=true",
+			"-refresh-only",
+		}, nil, applyCmd)
+	})
 }
 
 func TestApplyJSONCmd(t *testing.T) {

--- a/tfexec/options.go
+++ b/tfexec/options.go
@@ -327,6 +327,14 @@ func Refresh(refresh bool) *RefreshOption {
 	return &RefreshOption{refresh}
 }
 
+type RefreshOnlyOption struct {
+	refreshOnly bool
+}
+
+func RefreshOnly(refreshOnly bool) *RefreshOnlyOption {
+	return &RefreshOnlyOption{refreshOnly}
+}
+
 type ReplaceOption struct {
 	address string
 }

--- a/tfexec/plan.go
+++ b/tfexec/plan.go
@@ -20,6 +20,7 @@ type planConfig struct {
 	parallelism  int
 	reattachInfo ReattachInfo
 	refresh      bool
+	refreshOnly  bool
 	replaceAddrs []string
 	state        string
 	targets      []string
@@ -66,6 +67,10 @@ func (opt *ReattachOption) configurePlan(conf *planConfig) {
 
 func (opt *RefreshOption) configurePlan(conf *planConfig) {
 	conf.refresh = opt.refresh
+}
+
+func (opt *RefreshOnlyOption) configurePlan(conf *planConfig) {
+	conf.refreshOnly = opt.refreshOnly
 }
 
 func (opt *ReplaceOption) configurePlan(conf *planConfig) {
@@ -201,6 +206,17 @@ func (tf *Terraform) buildPlanArgs(ctx context.Context, c planConfig) ([]string,
 	args = append(args, "-lock="+strconv.FormatBool(c.lock))
 	args = append(args, "-parallelism="+fmt.Sprint(c.parallelism))
 	args = append(args, "-refresh="+strconv.FormatBool(c.refresh))
+
+	if c.refreshOnly {
+		err := tf.compatible(ctx, tf0_15_4, nil)
+		if err != nil {
+			return nil, fmt.Errorf("refresh-only option was introduced in Terraform 0.15.4: %w", err)
+		}
+		if !c.refresh {
+			return nil, fmt.Errorf("you cannot use refresh=false in refresh-only planning mode")
+		}
+		args = append(args, "-refresh-only")
+	}
 
 	// unary flags: pass if true
 	if c.replaceAddrs != nil {

--- a/tfexec/plan_test.go
+++ b/tfexec/plan_test.go
@@ -82,6 +82,25 @@ func TestPlanCmd(t *testing.T) {
 			"earth",
 		}, nil, planCmd)
 	})
+
+	t.Run("run a refresh-only plan", func(t *testing.T) {
+		planCmd, err := tf.planCmd(context.Background(), RefreshOnly(true))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assertCmd(t, []string{
+			"plan",
+			"-no-color",
+			"-input=false",
+			"-detailed-exitcode",
+			"-lock-timeout=0s",
+			"-lock=true",
+			"-parallelism=10",
+			"-refresh=true",
+			"-refresh-only",
+		}, nil, planCmd)
+	})
 }
 
 func TestPlanJSONCmd(t *testing.T) {

--- a/tfexec/version.go
+++ b/tfexec/version.go
@@ -29,6 +29,7 @@ var (
 	tf0_15_0 = version.Must(version.NewVersion("0.15.0"))
 	tf0_15_2 = version.Must(version.NewVersion("0.15.2"))
 	tf0_15_3 = version.Must(version.NewVersion("0.15.3"))
+	tf0_15_4 = version.Must(version.NewVersion("0.15.4"))
 	tf1_1_0  = version.Must(version.NewVersion("1.1.0"))
 	tf1_4_0  = version.Must(version.NewVersion("1.4.0"))
 )


### PR DESCRIPTION
Added support for `-refresh-only` flag for both `Plan` and `Apply` methods.