### PR TITLE
Allow using a new process group for the terraform cli child process

### DIFF
--- a/tfexec/cmd.go
+++ b/tfexec/cmd.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"syscall"
 
 	"github.com/hashicorp/terraform-exec/internal/version"
 )
@@ -187,6 +188,12 @@ func (tf *Terraform) buildTerraformCmd(ctx context.Context, mergeEnv map[string]
 
 	cmd.Env = tf.buildEnv(mergeEnv)
 	cmd.Dir = tf.workingDir
+	// Create a new process group for the command
+	if tf.useSepProcessGroup {
+		cmd.SysProcAttr = &syscall.SysProcAttr{
+			Setpgid: true,
+		}
+	}
 
 	tf.logger.Printf("[INFO] running Terraform command: %s", cmd.String())
 

--- a/tfexec/terraform.go
+++ b/tfexec/terraform.go
@@ -49,6 +49,7 @@ type Terraform struct {
 	appendUserAgent    string
 	disablePluginTLS   bool
 	skipProviderVerify bool
+	useSepProcessGroup bool
 	env                map[string]string
 
 	stdout io.Writer
@@ -134,6 +135,13 @@ func (tf *Terraform) SetStdout(w io.Writer) {
 // flow. Any parsing necessary should be added as functionality to this package.
 func (tf *Terraform) SetStderr(w io.Writer) {
 	tf.stderr = w
+}
+
+// SetUseSeparateProcessGroup specifies whether to use a separate process group
+// when running Terraform Cmd.
+func (tf *Terraform) SetUseSeparateProcessGroup(use bool) error {
+	tf.useSepProcessGroup = use
+	return nil
 }
 
 // SetLog sets the TF_LOG environment variable for Terraform CLI execution.


### PR DESCRIPTION
Support using `syscall.SysProcAttr` with `Setpgid: true` on the Cmd struct, which creates a new process group for the child process.   
This effectively separates the child process from the parent process's signal group, so it won't receive the interrupt signal when you interrupt the parent process.  
Motivation - graceful shutdown implementation.  When receiving  CTRL+C the child process running terraform is interrupted, which is undesirable for my use case.

See: https://stackoverflow.com/questions/33165530/prevent-ctrlc-from-interrupting-exec-command-in-golang/33171307#33171307