### PR TITLE
github: Replace dependabot with internal tooling

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,3 @@ updates:
     schedule:
       interval: "daily"
     labels: ["dependencies"]
-
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    labels: ["dependencies"]


### PR DESCRIPTION
This disables dependabot for GHA to avoid conflicts with our own internal tooling, which comes with an added layer of trusted/reviewed revisions.
