### PR TITLE
feat: Add support for terraform plan -generate-config-out

### DIFF
--- a/tfexec/internal/e2etest/plan_test.go
+++ b/tfexec/internal/e2etest/plan_test.go
@@ -15,6 +15,10 @@ import (
 	"github.com/hashicorp/terraform-exec/tfexec/internal/testutil"
 )
 
+var (
+	generateConfigOutMinVersion = version.Must(version.NewVersion("1.5.0"))
+)
+
 func TestPlan(t *testing.T) {
 	runTest(t, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
 		err := tf.Init(context.Background())
@@ -86,6 +90,27 @@ func TestPlanJSON_TF015AndLater(t *testing.T) {
 		hasChanges, err := tf.PlanJSON(context.Background(), io.Discard)
 		if err != nil {
 			t.Fatalf("error running Apply: %s", err)
+		}
+		if !hasChanges {
+			t.Fatalf("expected: true, got: %t", hasChanges)
+		}
+	})
+}
+
+func TestPlanGenerateConfigOut(t *testing.T) {
+	runTest(t, "generate_config_out", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+		if tfv.LessThan(generateConfigOutMinVersion) {
+			t.Skip("terraform plan -generate-config-out was added in Terraform 1.5.0, so test is not valid")
+		}
+
+		err := tf.Init(context.Background())
+		if err != nil {
+			t.Fatalf("error running Init in test directory: %s", err)
+		}
+
+		hasChanges, err := tf.Plan(context.Background(), tfexec.GenerateConfigOut("generated.tf"))
+		if err != nil {
+			t.Fatalf("error running Plan: %s", err)
 		}
 		if !hasChanges {
 			t.Fatalf("expected: true, got: %t", hasChanges)

--- a/tfexec/internal/e2etest/testdata/generate_config_out/main.tf
+++ b/tfexec/internal/e2etest/testdata/generate_config_out/main.tf
@@ -1,0 +1,4 @@
+import {
+  id = "bar"
+  to = terraform_data.foo
+}

--- a/tfexec/internal/testutil/tfcache.go
+++ b/tfexec/internal/testutil/tfcache.go
@@ -22,8 +22,8 @@ const (
 	Latest015   = "0.15.5"
 	Latest_v1   = "1.0.11"
 	Latest_v1_1 = "1.1.9"
-	Latest_v1_5 = "1.5.3"
-	Latest_v1_6 = "1.6.0-alpha20230719"
+	Latest_v1_5 = "1.5.7"
+	Latest_v1_6 = "1.6.6"
 )
 
 const appendUserAgent = "tfexec-testutil"

--- a/tfexec/options.go
+++ b/tfexec/options.go
@@ -172,6 +172,15 @@ func FromModule(source string) *FromModuleOption {
 	return &FromModuleOption{source}
 }
 
+type GenerateConfigOutOption struct {
+	generateConfigOut string
+}
+
+// GenerateConfigOut represents the -generate-config-out flag.
+func GenerateConfigOut(generateConfigOut string) *GenerateConfigOutOption {
+	return &GenerateConfigOutOption{generateConfigOut}
+}
+
 type GetOption struct {
 	get bool
 }

--- a/tfexec/plan.go
+++ b/tfexec/plan.go
@@ -12,20 +12,21 @@ import (
 )
 
 type planConfig struct {
-	destroy      bool
-	dir          string
-	lock         bool
-	lockTimeout  string
-	out          string
-	parallelism  int
-	reattachInfo ReattachInfo
-	refresh      bool
-	refreshOnly  bool
-	replaceAddrs []string
-	state        string
-	targets      []string
-	vars         []string
-	varFiles     []string
+	destroy           bool
+	dir               string
+	generateConfigOut string
+	lock              bool
+	lockTimeout       string
+	out               string
+	parallelism       int
+	reattachInfo      ReattachInfo
+	refresh           bool
+	refreshOnly       bool
+	replaceAddrs      []string
+	state             string
+	targets           []string
+	vars              []string
+	varFiles          []string
 }
 
 var defaultPlanOptions = planConfig{
@@ -95,6 +96,10 @@ func (opt *LockOption) configurePlan(conf *planConfig) {
 
 func (opt *DestroyFlagOption) configurePlan(conf *planConfig) {
 	conf.destroy = opt.destroy
+}
+
+func (opt *GenerateConfigOutOption) configurePlan(conf *planConfig) {
+	conf.generateConfigOut = opt.generateConfigOut
 }
 
 // Plan executes `terraform plan` with the specified options and waits for it
@@ -189,6 +194,13 @@ func (tf *Terraform) buildPlanArgs(ctx context.Context, c planConfig) ([]string,
 	args := []string{"plan", "-no-color", "-input=false", "-detailed-exitcode"}
 
 	// string opts: only pass if set
+	if c.generateConfigOut != "" {
+		err := tf.compatible(ctx, tf1_5_0, nil)
+		if err != nil {
+			return nil, fmt.Errorf("generate-config-out option was introduced in Terraform 1.5.0: %w", err)
+		}
+		args = append(args, "-generate-config-out="+c.generateConfigOut)
+	}
 	if c.lockTimeout != "" {
 		args = append(args, "-lock-timeout="+c.lockTimeout)
 	}

--- a/tfexec/plan_test.go
+++ b/tfexec/plan_test.go
@@ -13,7 +13,7 @@ import (
 func TestPlanCmd(t *testing.T) {
 	td := t.TempDir()
 
-	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest_v1))
+	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest_v1_5))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -101,12 +101,31 @@ func TestPlanCmd(t *testing.T) {
 			"-refresh-only",
 		}, nil, planCmd)
 	})
+
+	t.Run("run a generate-config-out plan", func(t *testing.T) {
+		planCmd, err := tf.planCmd(context.Background(), GenerateConfigOut("generated.tf"))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assertCmd(t, []string{
+			"plan",
+			"-no-color",
+			"-input=false",
+			"-detailed-exitcode",
+			"-generate-config-out=generated.tf",
+			"-lock-timeout=0s",
+			"-lock=true",
+			"-parallelism=10",
+			"-refresh=true",
+		}, nil, planCmd)
+	})
 }
 
 func TestPlanJSONCmd(t *testing.T) {
 	td := t.TempDir()
 
-	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest_v1))
+	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest_v1_5))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -175,6 +194,26 @@ func TestPlanJSONCmd(t *testing.T) {
 			"-var", "brain_size=planet",
 			"-json",
 			"earth",
+		}, nil, planCmd)
+	})
+
+	t.Run("generate-config-out", func(t *testing.T) {
+		planCmd, err := tf.planJSONCmd(context.Background(), GenerateConfigOut("generated.tf"))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assertCmd(t, []string{
+			"plan",
+			"-no-color",
+			"-input=false",
+			"-detailed-exitcode",
+			"-generate-config-out=generated.tf",
+			"-lock-timeout=0s",
+			"-lock=true",
+			"-parallelism=10",
+			"-refresh=true",
+			"-json",
 		}, nil, planCmd)
 	})
 }

--- a/tfexec/version.go
+++ b/tfexec/version.go
@@ -32,6 +32,7 @@ var (
 	tf0_15_4 = version.Must(version.NewVersion("0.15.4"))
 	tf1_1_0  = version.Must(version.NewVersion("1.1.0"))
 	tf1_4_0  = version.Must(version.NewVersion("1.4.0"))
+	tf1_5_0  = version.Must(version.NewVersion("1.5.0"))
 	tf1_6_0  = version.Must(version.NewVersion("1.6.0"))
 )
 


### PR DESCRIPTION
This PR adds support for the `-generate-config-out` flag in the `terraform plan command`, which was introduced in Terraform 1.5.0.

Closes #423 