### PR TITLE
tfexec: Add `-allow-deferral` experimental options to `Plan` and `Apply` commands

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,7 +49,7 @@ jobs:
     name: static-checks (go ${{ matrix.go_version }})
     needs: resolve-versions
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:
@@ -80,7 +80,7 @@ jobs:
       - resolve-versions
       - static-checks
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 10
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,7 +49,7 @@ jobs:
     name: static-checks (go ${{ matrix.go_version }})
     needs: resolve-versions
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,7 @@
 # 0.21.0 (Unreleased)
 
 ENHANCEMENTS:
-<!-- TODO: Update changelog -->
-- tfexec: Add `-allow-deferral` to `(Terraform).Apply()` and `(Terraform).Plan()` methods ([#TBD](https://github.com/hashicorp/terraform-exec/pull/TBD))
+- tfexec: Add `-allow-deferral` to `(Terraform).Apply()` and `(Terraform).Plan()` methods ([#447](https://github.com/hashicorp/terraform-exec/pull/447))
 
 # 0.20.0 (December 20, 2023)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.21.0 (Unreleased)
+
+ENHANCEMENTS:
+<!-- TODO: Update changelog -->
+- tfexec: Add `-allow-deferral` to `(Terraform).Apply()` and `(Terraform).Plan()` methods ([#TBD](https://github.com/hashicorp/terraform-exec/pull/TBD))
+
 # 0.20.0 (December 20, 2023)
 
 ENHANCEMENTS:

--- a/tfexec/apply.go
+++ b/tfexec/apply.go
@@ -12,10 +12,11 @@ import (
 )
 
 type applyConfig struct {
-	backup    string
-	destroy   bool
-	dirOrPlan string
-	lock      bool
+	allowDeferral bool
+	backup        string
+	destroy       bool
+	dirOrPlan     string
+	lock          bool
 
 	// LockTimeout must be a string with time unit, e.g. '10s'
 	lockTimeout  string
@@ -103,6 +104,10 @@ func (opt *ReattachOption) configureApply(conf *applyConfig) {
 
 func (opt *DestroyFlagOption) configureApply(conf *applyConfig) {
 	conf.destroy = opt.destroy
+}
+
+func (opt *AllowDeferralOption) configureApply(conf *applyConfig) {
+	conf.allowDeferral = opt.allowDeferral
 }
 
 // Apply represents the terraform apply subcommand.
@@ -230,6 +235,11 @@ func (tf *Terraform) buildApplyArgs(ctx context.Context, c applyConfig) ([]strin
 		for _, v := range c.vars {
 			args = append(args, "-var", v)
 		}
+	}
+
+	if c.allowDeferral {
+		// TODO: add tf.compatibile check here for alpha/pre-release
+		args = append(args, "-allow-deferral")
 	}
 
 	return args, nil

--- a/tfexec/apply.go
+++ b/tfexec/apply.go
@@ -238,7 +238,18 @@ func (tf *Terraform) buildApplyArgs(ctx context.Context, c applyConfig) ([]strin
 	}
 
 	if c.allowDeferral {
-		// TODO: add tf.compatibile check here for alpha/pre-release
+		// Ensure the version is later than 1.9.0
+		err := tf.compatible(ctx, tf1_9_0, nil)
+		if err != nil {
+			return nil, fmt.Errorf("allow-deferral is an experimental option introduced in Terraform 1.9.0: %w", err)
+		}
+
+		// Ensure the version has experiments enabled (alpha or dev builds)
+		err = tf.experimentsEnabled(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("allow-deferral is only available in experimental Terraform builds: %w", err)
+		}
+
 		args = append(args, "-allow-deferral")
 	}
 

--- a/tfexec/apply.go
+++ b/tfexec/apply.go
@@ -241,13 +241,13 @@ func (tf *Terraform) buildApplyArgs(ctx context.Context, c applyConfig) ([]strin
 		// Ensure the version is later than 1.9.0
 		err := tf.compatible(ctx, tf1_9_0, nil)
 		if err != nil {
-			return nil, fmt.Errorf("allow-deferral is an experimental option introduced in Terraform 1.9.0: %w", err)
+			return nil, fmt.Errorf("-allow-deferral is an experimental option introduced in Terraform 1.9.0: %w", err)
 		}
 
 		// Ensure the version has experiments enabled (alpha or dev builds)
 		err = tf.experimentsEnabled(ctx)
 		if err != nil {
-			return nil, fmt.Errorf("allow-deferral is only available in experimental Terraform builds: %w", err)
+			return nil, fmt.Errorf("-allow-deferral is only available in experimental Terraform builds: %w", err)
 		}
 
 		args = append(args, "-allow-deferral")

--- a/tfexec/apply_test.go
+++ b/tfexec/apply_test.go
@@ -89,27 +89,6 @@ func TestApplyCmd(t *testing.T) {
 			"-refresh-only",
 		}, nil, applyCmd)
 	})
-
-	// TODO: Move to a new test for just alpha builds?
-	t.Run("allow deferrals during apply", func(t *testing.T) {
-		applyCmd, err := tf.applyCmd(context.Background(),
-			AllowDeferral(true),
-		)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		assertCmd(t, []string{
-			"apply",
-			"-no-color",
-			"-auto-approve",
-			"-input=false",
-			"-lock=true",
-			"-parallelism=10",
-			"-refresh=true",
-			"-allow-deferral",
-		}, nil, applyCmd)
-	})
 }
 
 func TestApplyJSONCmd(t *testing.T) {
@@ -168,6 +147,38 @@ func TestApplyJSONCmd(t *testing.T) {
 			"-var", "var2=bar",
 			"-json",
 			"testfile",
+		}, nil, applyCmd)
+	})
+}
+
+func TestApplyCmd_AllowDeferral(t *testing.T) {
+	td := t.TempDir()
+
+	tf, err := NewTerraform(td, tfVersion(t, testutil.Alpha_v1_9))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// empty env, to avoid environ mismatch in testing
+	tf.SetEnv(map[string]string{})
+
+	t.Run("allow deferrals during apply", func(t *testing.T) {
+		applyCmd, err := tf.applyCmd(context.Background(),
+			AllowDeferral(true),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assertCmd(t, []string{
+			"apply",
+			"-no-color",
+			"-auto-approve",
+			"-input=false",
+			"-lock=true",
+			"-parallelism=10",
+			"-refresh=true",
+			"-allow-deferral",
 		}, nil, applyCmd)
 	})
 }

--- a/tfexec/apply_test.go
+++ b/tfexec/apply_test.go
@@ -89,6 +89,27 @@ func TestApplyCmd(t *testing.T) {
 			"-refresh-only",
 		}, nil, applyCmd)
 	})
+
+	// TODO: Move to a new test for just alpha builds?
+	t.Run("allow deferrals during apply", func(t *testing.T) {
+		applyCmd, err := tf.applyCmd(context.Background(),
+			AllowDeferral(true),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assertCmd(t, []string{
+			"apply",
+			"-no-color",
+			"-auto-approve",
+			"-input=false",
+			"-lock=true",
+			"-parallelism=10",
+			"-refresh=true",
+			"-allow-deferral",
+		}, nil, applyCmd)
+	})
 }
 
 func TestApplyJSONCmd(t *testing.T) {

--- a/tfexec/force_unlock_test.go
+++ b/tfexec/force_unlock_test.go
@@ -5,6 +5,7 @@ package tfexec
 
 import (
 	"context"
+	"runtime"
 	"testing"
 
 	"github.com/hashicorp/terraform-exec/tfexec/internal/testutil"
@@ -39,6 +40,10 @@ func TestForceUnlockCmd(t *testing.T) {
 // The optional final positional [DIR] argument is available
 // until v0.15.0.
 func TestForceUnlockCmd_pre015(t *testing.T) {
+	if runtime.GOOS == "darwin" && runtime.GOARCH == "arm64" {
+		t.Skip("Terraform for darwin/arm64 is not available until v1")
+	}
+
 	td := t.TempDir()
 
 	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest014))

--- a/tfexec/internal/testutil/tfcache.go
+++ b/tfexec/internal/testutil/tfcache.go
@@ -24,6 +24,9 @@ const (
 	Latest_v1_1 = "1.1.9"
 	Latest_v1_5 = "1.5.3"
 	Latest_v1_6 = "1.6.0-alpha20230719"
+
+	Beta_v1_8  = "1.8.0-beta1"
+	Alpha_v1_9 = "1.9.0-alpha20240404"
 )
 
 const appendUserAgent = "tfexec-testutil"

--- a/tfexec/options.go
+++ b/tfexec/options.go
@@ -7,6 +7,16 @@ import (
 	"encoding/json"
 )
 
+// TODO: add doc
+type AllowDeferralOption struct {
+	allowDeferral bool
+}
+
+// TODO: add doc
+func AllowDeferral(allowDeferral bool) *AllowDeferralOption {
+	return &AllowDeferralOption{allowDeferral}
+}
+
 // AllowMissingConfigOption represents the -allow-missing-config flag.
 type AllowMissingConfigOption struct {
 	allowMissingConfig bool

--- a/tfexec/options.go
+++ b/tfexec/options.go
@@ -7,12 +7,14 @@ import (
 	"encoding/json"
 )
 
-// TODO: add doc
+// AllowDeferralOption represents the -allow-deferral flag. This flag is only enabled in
+// experimental builds of Terraform. (alpha or built via source with experiments enabled)
 type AllowDeferralOption struct {
 	allowDeferral bool
 }
 
-// TODO: add doc
+// AllowDeferral represents the -allow-deferral flag. This flag is only enabled in
+// experimental builds of Terraform. (alpha or built via source with experiments enabled)
 func AllowDeferral(allowDeferral bool) *AllowDeferralOption {
 	return &AllowDeferralOption{allowDeferral}
 }

--- a/tfexec/plan.go
+++ b/tfexec/plan.go
@@ -249,7 +249,18 @@ func (tf *Terraform) buildPlanArgs(ctx context.Context, c planConfig) ([]string,
 		}
 	}
 	if c.allowDeferral {
-		// TODO: add tf.compatibile check here for alpha/pre-release
+		// Ensure the version is later than 1.9.0
+		err := tf.compatible(ctx, tf1_9_0, nil)
+		if err != nil {
+			return nil, fmt.Errorf("allow-deferral is an experimental option introduced in Terraform 1.9.0: %w", err)
+		}
+
+		// Ensure the version has experiments enabled (alpha or dev builds)
+		err = tf.experimentsEnabled(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("allow-deferral is only available in experimental Terraform builds: %w", err)
+		}
+
 		args = append(args, "-allow-deferral")
 	}
 

--- a/tfexec/plan.go
+++ b/tfexec/plan.go
@@ -252,13 +252,13 @@ func (tf *Terraform) buildPlanArgs(ctx context.Context, c planConfig) ([]string,
 		// Ensure the version is later than 1.9.0
 		err := tf.compatible(ctx, tf1_9_0, nil)
 		if err != nil {
-			return nil, fmt.Errorf("allow-deferral is an experimental option introduced in Terraform 1.9.0: %w", err)
+			return nil, fmt.Errorf("-allow-deferral is an experimental option introduced in Terraform 1.9.0: %w", err)
 		}
 
 		// Ensure the version has experiments enabled (alpha or dev builds)
 		err = tf.experimentsEnabled(ctx)
 		if err != nil {
-			return nil, fmt.Errorf("allow-deferral is only available in experimental Terraform builds: %w", err)
+			return nil, fmt.Errorf("-allow-deferral is only available in experimental Terraform builds: %w", err)
 		}
 
 		args = append(args, "-allow-deferral")

--- a/tfexec/plan.go
+++ b/tfexec/plan.go
@@ -12,20 +12,21 @@ import (
 )
 
 type planConfig struct {
-	destroy      bool
-	dir          string
-	lock         bool
-	lockTimeout  string
-	out          string
-	parallelism  int
-	reattachInfo ReattachInfo
-	refresh      bool
-	refreshOnly  bool
-	replaceAddrs []string
-	state        string
-	targets      []string
-	vars         []string
-	varFiles     []string
+	allowDeferral bool
+	destroy       bool
+	dir           string
+	lock          bool
+	lockTimeout   string
+	out           string
+	parallelism   int
+	reattachInfo  ReattachInfo
+	refresh       bool
+	refreshOnly   bool
+	replaceAddrs  []string
+	state         string
+	targets       []string
+	vars          []string
+	varFiles      []string
 }
 
 var defaultPlanOptions = planConfig{
@@ -95,6 +96,10 @@ func (opt *LockOption) configurePlan(conf *planConfig) {
 
 func (opt *DestroyFlagOption) configurePlan(conf *planConfig) {
 	conf.destroy = opt.destroy
+}
+
+func (opt *AllowDeferralOption) configurePlan(conf *planConfig) {
+	conf.allowDeferral = opt.allowDeferral
 }
 
 // Plan executes `terraform plan` with the specified options and waits for it
@@ -242,6 +247,10 @@ func (tf *Terraform) buildPlanArgs(ctx context.Context, c planConfig) ([]string,
 		for _, v := range c.vars {
 			args = append(args, "-var", v)
 		}
+	}
+	if c.allowDeferral {
+		// TODO: add tf.compatibile check here for alpha/pre-release
+		args = append(args, "-allow-deferral")
 	}
 
 	return args, nil

--- a/tfexec/plan_test.go
+++ b/tfexec/plan_test.go
@@ -101,6 +101,26 @@ func TestPlanCmd(t *testing.T) {
 			"-refresh-only",
 		}, nil, planCmd)
 	})
+
+	// TODO: Move to a new test for just alpha builds?
+	t.Run("allow deferrals during plan", func(t *testing.T) {
+		planCmd, err := tf.planCmd(context.Background(), AllowDeferral(true))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assertCmd(t, []string{
+			"plan",
+			"-no-color",
+			"-input=false",
+			"-detailed-exitcode",
+			"-lock-timeout=0s",
+			"-lock=true",
+			"-parallelism=10",
+			"-refresh=true",
+			"-allow-deferral",
+		}, nil, planCmd)
+	})
 }
 
 func TestPlanJSONCmd(t *testing.T) {

--- a/tfexec/plan_test.go
+++ b/tfexec/plan_test.go
@@ -101,26 +101,6 @@ func TestPlanCmd(t *testing.T) {
 			"-refresh-only",
 		}, nil, planCmd)
 	})
-
-	// TODO: Move to a new test for just alpha builds?
-	t.Run("allow deferrals during plan", func(t *testing.T) {
-		planCmd, err := tf.planCmd(context.Background(), AllowDeferral(true))
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		assertCmd(t, []string{
-			"plan",
-			"-no-color",
-			"-input=false",
-			"-detailed-exitcode",
-			"-lock-timeout=0s",
-			"-lock=true",
-			"-parallelism=10",
-			"-refresh=true",
-			"-allow-deferral",
-		}, nil, planCmd)
-	})
 }
 
 func TestPlanJSONCmd(t *testing.T) {
@@ -195,6 +175,37 @@ func TestPlanJSONCmd(t *testing.T) {
 			"-var", "brain_size=planet",
 			"-json",
 			"earth",
+		}, nil, planCmd)
+	})
+}
+
+func TestPlanCmd_AllowDeferral(t *testing.T) {
+	td := t.TempDir()
+
+	tf, err := NewTerraform(td, tfVersion(t, testutil.Alpha_v1_9))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// empty env, to avoid environ mismatch in testing
+	tf.SetEnv(map[string]string{})
+
+	t.Run("allow deferrals during plan", func(t *testing.T) {
+		planCmd, err := tf.planCmd(context.Background(), AllowDeferral(true))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assertCmd(t, []string{
+			"plan",
+			"-no-color",
+			"-input=false",
+			"-detailed-exitcode",
+			"-lock-timeout=0s",
+			"-lock=true",
+			"-parallelism=10",
+			"-refresh=true",
+			"-allow-deferral",
 		}, nil, planCmd)
 	})
 }

--- a/tfexec/version.go
+++ b/tfexec/version.go
@@ -33,6 +33,7 @@ var (
 	tf1_1_0  = version.Must(version.NewVersion("1.1.0"))
 	tf1_4_0  = version.Must(version.NewVersion("1.4.0"))
 	tf1_6_0  = version.Must(version.NewVersion("1.6.0"))
+	tf1_9_0  = version.Must(version.NewVersion("1.9.0"))
 )
 
 // Version returns structured output from the terraform version command including both the Terraform CLI version
@@ -178,6 +179,23 @@ func (tf *Terraform) compatible(ctx context.Context, minInclusive *version.Versi
 	}
 
 	return nil
+}
+
+// experimentsEnabled asserts the cached terraform version has experiments enabled in the executable, and returns a well known error if not.
+//
+// Experiments are enabled in alpha and (potentially) dev builds of Terraform.
+func (tf *Terraform) experimentsEnabled(ctx context.Context) error {
+	tfv, _, err := tf.Version(ctx, false)
+	if err != nil {
+		return err
+	}
+
+	preRelease := tfv.Prerelease()
+	if preRelease == "dev" || strings.Contains(preRelease, "alpha") {
+		return nil
+	}
+
+	return fmt.Errorf("experiments are not enabled in version %s, as it's not an alpha or dev build", errorVersionString(tfv))
 }
 
 func stripPrereleaseAndMeta(v *version.Version) *version.Version {

--- a/tfexec/version.go
+++ b/tfexec/version.go
@@ -181,9 +181,8 @@ func (tf *Terraform) compatible(ctx context.Context, minInclusive *version.Versi
 	return nil
 }
 
-// experimentsEnabled asserts the cached terraform version has experiments enabled in the executable, and returns a well known error if not.
-//
-// Experiments are enabled in alpha and (potentially) dev builds of Terraform.
+// experimentsEnabled asserts the cached terraform version has experiments enabled in the executable,
+// and returns a well known error if not. Experiments are enabled in alpha and (potentially) dev builds of Terraform.
 func (tf *Terraform) experimentsEnabled(ctx context.Context) error {
 	tfv, _, err := tf.Version(ctx, false)
 	if err != nil {


### PR DESCRIPTION
This PR introduces a new plan and apply flag `-allow-deferral`. This flag enables the deferred actions experiment that was introduced in Terraform [`v1.9.0-alpha20240404`](https://github.com/hashicorp/terraform/releases/tag/v1.9.0-alpha20240404)


### Notes
- I wasn't sure if there was an _external_ interface for checking that experiments are enabled from the Terraform CLI, so I just check for `alpha` or `dev` in the version as a best effort. Happy to update with a more accurate method if one exists!