### PR TITLE
Add migrate state flag to init command.

### DIFF
--- a/tfexec/init.go
+++ b/tfexec/init.go
@@ -164,6 +164,9 @@ func (tf *Terraform) initCmd(ctx context.Context, opts ...InitOption) (*exec.Cmd
 	// -migrate-state added in 0.15.4 before it was automatic and returned errors
 	err = tf.compatible(ctx, tf0_15_4, nil)
 	if err == nil {
+		if c.migrate && c.reconfigure {
+			return nil, fmt.Errorf("the -migrate-state and -reconfigure options are mutually-exclusive")
+		}
 		if c.migrate {
 			args = append(args, "-migrate-state")
 		}

--- a/tfexec/init_test.go
+++ b/tfexec/init_test.go
@@ -48,35 +48,7 @@ func TestInitCmd_v012(t *testing.T) {
 	})
 
 	t.Run("override all defaults", func(t *testing.T) {
-		initCmd, err := tf.initCmd(context.Background(), Backend(false), BackendConfig("confpath1"), BackendConfig("confpath2"), ForceCopy(true), FromModule("testsource"), Get(false), GetPlugins(false), Lock(false), LockTimeout("999s"), PluginDir("testdir1"), PluginDir("testdir2"), Reconfigure(true), Upgrade(true), VerifyPlugins(false), Dir("initdir"))
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		assertCmd(t, []string{
-			"init",
-			"-no-color",
-			"-input=false",
-			"-from-module=testsource",
-			"-lock-timeout=999s",
-			"-backend=false",
-			"-get=false",
-			"-upgrade=true",
-			"-lock=false",
-			"-get-plugins=false",
-			"-verify-plugins=false",
-			"-force-copy",
-			"-reconfigure",
-			"-backend-config=confpath1",
-			"-backend-config=confpath2",
-			"-plugin-dir=testdir1",
-			"-plugin-dir=testdir2",
-			"initdir",
-		}, nil, initCmd)
-	})
-
-	t.Run("override all defaults migrate", func(t *testing.T) {
-		initCmd, err := tf.initCmd(context.Background(), Backend(false), BackendConfig("confpath1"), BackendConfig("confpath2"), ForceCopy(true), FromModule("testsource"), Get(false), GetPlugins(false), Lock(false), LockTimeout("999s"), PluginDir("testdir1"), PluginDir("testdir2"), MigrateState(true), Upgrade(true), VerifyPlugins(false), Dir("initdir"))
+		initCmd, err := tf.initCmd(context.Background(), Backend(false), BackendConfig("confpath1"), BackendConfig("confpath2"), ForceCopy(true), FromModule("testsource"), Get(false), GetPlugins(false), Lock(false), LockTimeout("999s"), PluginDir("testdir1"), PluginDir("testdir2"), Reconfigure(true), MigrateState(true), Upgrade(true), VerifyPlugins(false), Dir("initdir"))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -132,6 +104,17 @@ func TestInitCmd_v1(t *testing.T) {
 		}, nil, initCmd)
 	})
 
+	t.Run("reconfigure and migrate error", func(t *testing.T) {
+		// defaults
+		initCmd, err := tf.initCmd(context.Background(), Reconfigure(true), MigrateState(true))
+		if err == nil {
+			t.Fatal("expected -migrate-state and -reconfigure options are mutually-exclusive error")
+		}
+		if initCmd != nil {
+			t.Fatal("error returned and command not null")
+		}
+	})
+
 	t.Run("override all defaults", func(t *testing.T) {
 		initCmd, err := tf.initCmd(context.Background(), Backend(false), BackendConfig("confpath1"), BackendConfig("confpath2"), FromModule("testsource"), Get(false), PluginDir("testdir1"), PluginDir("testdir2"), Reconfigure(true), Upgrade(true), Dir("initdir"))
 		if err != nil {
@@ -147,6 +130,29 @@ func TestInitCmd_v1(t *testing.T) {
 			"-get=false",
 			"-upgrade=true",
 			"-reconfigure",
+			"-backend-config=confpath1",
+			"-backend-config=confpath2",
+			"-plugin-dir=testdir1",
+			"-plugin-dir=testdir2",
+			"initdir",
+		}, nil, initCmd)
+	})
+
+	t.Run("override all defaults with migrate", func(t *testing.T) {
+		initCmd, err := tf.initCmd(context.Background(), Backend(false), BackendConfig("confpath1"), BackendConfig("confpath2"), FromModule("testsource"), Get(false), PluginDir("testdir1"), PluginDir("testdir2"), MigrateState(true), Upgrade(true), Dir("initdir"))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assertCmd(t, []string{
+			"init",
+			"-no-color",
+			"-input=false",
+			"-from-module=testsource",
+			"-backend=false",
+			"-get=false",
+			"-upgrade=true",
+			"-migrate-state",
 			"-backend-config=confpath1",
 			"-backend-config=confpath2",
 			"-plugin-dir=testdir1",

--- a/tfexec/init_test.go
+++ b/tfexec/init_test.go
@@ -74,6 +74,34 @@ func TestInitCmd_v012(t *testing.T) {
 			"initdir",
 		}, nil, initCmd)
 	})
+
+	t.Run("override all defaults migrate", func(t *testing.T) {
+		initCmd, err := tf.initCmd(context.Background(), Backend(false), BackendConfig("confpath1"), BackendConfig("confpath2"), ForceCopy(true), FromModule("testsource"), Get(false), GetPlugins(false), Lock(false), LockTimeout("999s"), PluginDir("testdir1"), PluginDir("testdir2"), MigrateState(true), Upgrade(true), VerifyPlugins(false), Dir("initdir"))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assertCmd(t, []string{
+			"init",
+			"-no-color",
+			"-input=false",
+			"-from-module=testsource",
+			"-lock-timeout=999s",
+			"-backend=false",
+			"-get=false",
+			"-upgrade=true",
+			"-lock=false",
+			"-get-plugins=false",
+			"-verify-plugins=false",
+			"-force-copy",
+			"-reconfigure",
+			"-backend-config=confpath1",
+			"-backend-config=confpath2",
+			"-plugin-dir=testdir1",
+			"-plugin-dir=testdir2",
+			"initdir",
+		}, nil, initCmd)
+	})
 }
 
 func TestInitCmd_v1(t *testing.T) {

--- a/tfexec/options.go
+++ b/tfexec/options.go
@@ -221,6 +221,15 @@ func LockTimeout(lockTimeout string) *LockTimeoutOption {
 	return &LockTimeoutOption{lockTimeout}
 }
 
+type MigrateStateOption struct {
+	migrate bool
+}
+
+// MigrateState represents the -migrate-state flag.
+func MigrateState(migrate bool) *MigrateStateOption {
+	return &MigrateStateOption{migrate}
+}
+
 type NetMirrorOption struct {
 	netMirror string
 }


### PR DESCRIPTION
Add support for `-migrate-state` flag after 0.15.4 where the migration is not automatic anymore.

Addresses issue #355

Another use case is to create the backend infrastructure (E.G. S3 and DynamoDB) and then migrate the state and apply other targets.