### PR TITLE
Remove e2e test (support) for 0.11

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -132,7 +132,6 @@ jobs:
           - ${{ needs.resolve-versions.outputs.oldstable }}
           - ${{ needs.resolve-versions.outputs.stable }}
         terraform_version:
-          - "0.11.15"
           - "0.12.31"
           - "0.13.7"
           - "0.14.11"

--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ This library is built in Go, and uses the [support policy](https://golang.org/do
 
 Currently, that means Go **1.22** or later must be used.
 
+## Terraform compatibility
+
+We generally follow [Terraform's own compatibility promises](https://developer.hashicorp.com/terraform/language/v1-compatibility-promises). i.e. **we recommend Terraform v1.x to be used alongside this library**.
+
+Given the nature of this library being used in automation, we maintain compatibility **on best effort basis** with latest minor versions from `0.12` and later. This does not imply coverage of all features or CLI surface, just that it shouldn't break in unexpected ways.
+
 ## Usage
 
 The `Terraform` struct must be initialised with `NewTerraform(workingDir, execPath)`. 


### PR DESCRIPTION
This should unblock any/all pending PRs which are currently failing, see https://github.com/hashicorp/terraform-exec/pull/507#issuecomment-2783760802 for more.