### PR TITLE
go: bump version to 1.23/1.24

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ We strictly follow [semantic versioning](https://semver.org).
 
 This library is built in Go, and uses the [support policy](https://golang.org/doc/devel/release.html#policy) of Go as its support policy. The two latest major releases of Go are supported by terraform-exec.
 
-Currently, that means Go **1.22** or later must be used.
+Currently, that means Go **1.23** or later must be used.
 
 ## Terraform compatibility
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/hashicorp/terraform-exec
 
-go 1.22.0
+go 1.23.0
+
+toolchain go1.24.0
 
 require (
 	github.com/google/go-cmp v0.7.0


### PR DESCRIPTION
This is to unblock https://github.com/hashicorp/terraform-exec/pull/507