### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # This codebase has shared ownership and responsibility.
 
-* @hashicorp/terraform-core @hashicorp/terraform-devex @hashicorp/tf-editor-experience-engineers
+* @hashicorp/terraform-core @hashicorp/terraform-core-plugins @hashicorp/tf-editor-experience-engineers


### PR DESCRIPTION
Our GH team name has been updated recently, so we're slowly moving over to `@hashicorp/terraform-core-plugins`

cc @bbasata 