### PR TITLE
Return errors from scanner in (LogMsgEmitter).NextMessage method

### DIFF
--- a/tfexec/cmd.go
+++ b/tfexec/cmd.go
@@ -256,12 +256,7 @@ type LogMsgEmitter struct {
 func (e *LogMsgEmitter) NextMessage() (tfjson.LogMsg, bool, error) {
 	ok := e.scanner.Scan()
 	if !ok {
-		err := e.scanner.Err()
-		if err == nil {
-			// Means the scanner encountered EOF
-			return nil, ok, io.EOF
-		}
-		// A non-EOF error occurred
+		err := e.scanner.Err() // If the error is EOF then err is nil
 		return nil, ok, err
 	}
 	msg, err := tfjson.UnmarshalLogMessage(e.scanner.Bytes())


### PR DESCRIPTION
## Related Issue

N/A

## Description

In response to internal feedback about handling EOF

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

None