### PR TITLE
Implement `QueryJSON` and introduce new way for consuming Terraform's structured logging

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/hashicorp/go-version v1.7.0
 	github.com/hashicorp/hc-install v0.9.2
-	github.com/hashicorp/terraform-json v0.26.0
+	github.com/hashicorp/terraform-json v0.27.0
 	github.com/zclconf/go-cty v1.16.4
 	github.com/zclconf/go-cty-debug v0.0.0-20191215020915-b22d67c1ba0b
 )

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/hashicorp/go-version v1.7.0
 	github.com/hashicorp/hc-install v0.9.2
-	github.com/hashicorp/terraform-json v0.27.0
+	github.com/hashicorp/terraform-json v0.27.1
 	github.com/zclconf/go-cty v1.16.4
 	github.com/zclconf/go-cty-debug v0.0.0-20191215020915-b22d67c1ba0b
 )

--- a/go.sum
+++ b/go.sum
@@ -51,8 +51,8 @@ github.com/hashicorp/go-version v1.7.0 h1:5tqGy27NaOTB8yJKUZELlFAS/LTKJkrmONwQKe
 github.com/hashicorp/go-version v1.7.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/hc-install v0.9.2 h1:v80EtNX4fCVHqzL9Lg/2xkp62bbvQMnvPQ0G+OmtO24=
 github.com/hashicorp/hc-install v0.9.2/go.mod h1:XUqBQNnuT4RsxoxiM9ZaUk0NX8hi2h+Lb6/c0OZnC/I=
-github.com/hashicorp/terraform-json v0.27.0 h1:REIlFzMMkIyTbhq69NC30bYiUYLv7iVhwM8ObnLo0p8=
-github.com/hashicorp/terraform-json v0.27.0/go.mod h1:GzPLJ1PLdUG5xL6xn1OXWIjteQRT2CNT9o/6A9mi9hE=
+github.com/hashicorp/terraform-json v0.27.1 h1:zWhEracxJW6lcjt/JvximOYyc12pS/gaKSy/wzzE7nY=
+github.com/hashicorp/terraform-json v0.27.1/go.mod h1:GzPLJ1PLdUG5xL6xn1OXWIjteQRT2CNT9o/6A9mi9hE=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=

--- a/go.sum
+++ b/go.sum
@@ -51,8 +51,8 @@ github.com/hashicorp/go-version v1.7.0 h1:5tqGy27NaOTB8yJKUZELlFAS/LTKJkrmONwQKe
 github.com/hashicorp/go-version v1.7.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/hc-install v0.9.2 h1:v80EtNX4fCVHqzL9Lg/2xkp62bbvQMnvPQ0G+OmtO24=
 github.com/hashicorp/hc-install v0.9.2/go.mod h1:XUqBQNnuT4RsxoxiM9ZaUk0NX8hi2h+Lb6/c0OZnC/I=
-github.com/hashicorp/terraform-json v0.26.0 h1:+BnJavhRH+oyNWPnfzrfQwVWCZBFMvjdiH2Vi38Udz4=
-github.com/hashicorp/terraform-json v0.26.0/go.mod h1:eyWCeC3nrZamyrKLFnrvwpc3LQPIJsx8hWHQ/nu2/v4=
+github.com/hashicorp/terraform-json v0.27.0 h1:REIlFzMMkIyTbhq69NC30bYiUYLv7iVhwM8ObnLo0p8=
+github.com/hashicorp/terraform-json v0.27.0/go.mod h1:GzPLJ1PLdUG5xL6xn1OXWIjteQRT2CNT9o/6A9mi9hE=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=

--- a/tfexec/internal/e2etest/query_test.go
+++ b/tfexec/internal/e2etest/query_test.go
@@ -1,0 +1,57 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package e2etest
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform-exec/tfexec"
+	"github.com/hashicorp/terraform-exec/tfexec/internal/testutil"
+)
+
+func TestQueryJSON_TF112(t *testing.T) {
+	versions := []string{testutil.Latest_v1_12}
+
+	runTestWithVersions(t, versions, "query", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+		err := tf.Init(context.Background())
+		if err != nil {
+			t.Fatalf("error running Init in test directory: %s", err)
+		}
+
+		re := regexp.MustCompile("terraform query -json was added in 1.14.0")
+
+		err = tf.QueryJSON(context.Background(), io.Discard)
+		if err != nil && !re.MatchString(err.Error()) {
+			t.Fatalf("error running Query: %s", err)
+		}
+	})
+}
+
+func TestQueryJSON_TF114(t *testing.T) {
+	versions := []string{testutil.Latest_Alpha_v1_14}
+
+	runTestWithVersions(t, versions, "query", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+		err := tf.Init(context.Background())
+		if err != nil {
+			t.Fatalf("error running Init in test directory: %s", err)
+		}
+
+		var output bytes.Buffer
+		err = tf.QueryJSON(context.Background(), &output)
+		if err != nil {
+			t.Fatalf("error running Query: %s", err)
+		}
+
+		results := strings.Count(output.String(), "list.concept_pet.pets: Result found")
+		if results != 5 {
+			t.Fatalf("expected 5 query results, but got %d", results)
+		}
+	})
+}

--- a/tfexec/internal/e2etest/query_test.go
+++ b/tfexec/internal/e2etest/query_test.go
@@ -4,16 +4,15 @@
 package e2etest
 
 import (
-	"bytes"
 	"context"
-	"io"
 	"regexp"
-	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-exec/tfexec"
 	"github.com/hashicorp/terraform-exec/tfexec/internal/testutil"
+	tfjson "github.com/hashicorp/terraform-json"
 )
 
 func TestQueryJSON_TF112(t *testing.T) {
@@ -27,7 +26,7 @@ func TestQueryJSON_TF112(t *testing.T) {
 
 		re := regexp.MustCompile("terraform query -json was added in 1.14.0")
 
-		err = tf.QueryJSON(context.Background(), io.Discard)
+		_, err = tf.QueryJSON(context.Background())
 		if err != nil && !re.MatchString(err.Error()) {
 			t.Fatalf("error running Query: %s", err)
 		}
@@ -43,15 +42,41 @@ func TestQueryJSON_TF114(t *testing.T) {
 			t.Fatalf("error running Init in test directory: %s", err)
 		}
 
-		var output bytes.Buffer
-		err = tf.QueryJSON(context.Background(), &output)
+		iter, err := tf.QueryJSON(context.Background())
 		if err != nil {
 			t.Fatalf("error running Query: %s", err)
 		}
 
-		results := strings.Count(output.String(), "list.concept_pet.pets: Result found")
+		results := 0
+		listingStarted := 0
+		var completeData tfjson.ListCompleteData
+		for nextMsg := range iter {
+			if nextMsg.Err != nil {
+				t.Fatalf("error getting next message: %s", err)
+			}
+			switch m := nextMsg.Msg.(type) {
+			case tfjson.ListStartMessage:
+				listingStarted++
+			case tfjson.ListResourceFoundMessage:
+				results++
+			case tfjson.ListCompleteMessage:
+				completeData = m.ListComplete
+			}
+		}
+
+		if listingStarted != 1 {
+			t.Fatalf("expected exactly 1 list start message, got %d", listingStarted)
+		}
 		if results != 5 {
-			t.Fatalf("expected 5 query results, but got %d", results)
+			t.Fatalf("expected 5 query results, got %d", results)
+		}
+		expectedData := tfjson.ListCompleteData{
+			Address:      "list.concept_pet.pets",
+			ResourceType: "concept_pet",
+			Total:        5,
+		}
+		if diff := cmp.Diff(expectedData, completeData); diff != "" {
+			t.Fatalf("unexpected complete message data: %s", diff)
 		}
 	})
 }

--- a/tfexec/internal/e2etest/testdata/query/main.tf
+++ b/tfexec/internal/e2etest/testdata/query/main.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    concept = {
+      source  = "dbanck/concept"
+      version = "0.1.0"
+    }
+  }
+}

--- a/tfexec/internal/e2etest/testdata/query/main.tfquery.hcl
+++ b/tfexec/internal/e2etest/testdata/query/main.tfquery.hcl
@@ -1,0 +1,3 @@
+list "concept_pet" "pets" {
+    provider = concept
+}

--- a/tfexec/internal/testutil/tfcache.go
+++ b/tfexec/internal/testutil/tfcache.go
@@ -36,6 +36,7 @@ const (
 	Latest_Alpha_v1_10 = "1.10.0-alpha20240926"
 	Latest_v1_11       = "1.11.4"
 	Latest_v1_12       = "1.12.2"
+	Latest_Alpha_v1_14 = "1.14.0-alpha20250903"
 )
 
 const appendUserAgent = "tfexec-testutil"

--- a/tfexec/options.go
+++ b/tfexec/options.go
@@ -184,6 +184,14 @@ func FromModule(source string) *FromModuleOption {
 	return &FromModuleOption{source}
 }
 
+type GenerateConfigOutOption struct {
+	path string
+}
+
+func GenerateConfigOut(path string) *GenerateConfigOutOption {
+	return &GenerateConfigOutOption{path}
+}
+
 type GetOption struct {
 	get bool
 }

--- a/tfexec/query.go
+++ b/tfexec/query.go
@@ -1,0 +1,134 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package tfexec
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os/exec"
+)
+
+type queryConfig struct {
+	dir            string
+	generateConfig string
+	reattachInfo   ReattachInfo
+	vars           []string
+	varFiles       []string
+}
+
+var defaultQueryOptions = queryConfig{}
+
+// QueryOption represents options used in the Query method.
+type QueryOption interface {
+	configureQuery(*queryConfig)
+}
+
+func (opt *DirOption) configureQuery(conf *queryConfig) {
+	conf.dir = opt.path
+}
+
+func (opt *GenerateConfigOutOption) configureQuery(conf *queryConfig) {
+	conf.generateConfig = opt.path
+}
+
+func (opt *ReattachOption) configureQuery(conf *queryConfig) {
+	conf.reattachInfo = opt.info
+}
+
+func (opt *VarFileOption) configureQuery(conf *queryConfig) {
+	conf.varFiles = append(conf.varFiles, opt.path)
+}
+
+func (opt *VarOption) configureQuery(conf *queryConfig) {
+	conf.vars = append(conf.vars, opt.assignment)
+}
+
+// QueryJSON executes `terraform query` with the specified options as well as the
+// `-json` flag and waits for it to complete.
+//
+// Using the `-json` flag will result in
+// [machine-readable](https://developer.hashicorp.com/terraform/internals/machine-readable-ui)
+// JSON being written to the supplied `io.Writer`.
+//
+// The returned error is nil if `terraform query` has been executed and exits
+// with 0.
+//
+// QueryJSON is likely to be removed in a future major version in favour of
+// query returning JSON by default.
+func (tf *Terraform) QueryJSON(ctx context.Context, w io.Writer, opts ...QueryOption) error {
+	err := tf.compatible(ctx, tf1_14_0, nil)
+	if err != nil {
+		return fmt.Errorf("terraform query -json was added in 1.14.0: %w", err)
+	}
+
+	tf.SetStdout(w)
+
+	cmd, err := tf.queryJSONCmd(ctx, opts...)
+	if err != nil {
+		return err
+	}
+
+	err = tf.runTerraformCmd(ctx, cmd)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (tf *Terraform) queryJSONCmd(ctx context.Context, opts ...QueryOption) (*exec.Cmd, error) {
+	c := defaultQueryOptions
+
+	for _, o := range opts {
+		o.configureQuery(&c)
+	}
+
+	args, err := tf.buildQueryArgs(ctx, c)
+	if err != nil {
+		return nil, err
+	}
+
+	args = append(args, "-json")
+
+	return tf.buildQueryCmd(ctx, c, args)
+}
+
+func (tf *Terraform) buildQueryArgs(ctx context.Context, c queryConfig) ([]string, error) {
+	args := []string{"query", "-no-color"}
+
+	if c.generateConfig != "" {
+		args = append(args, "-generate-config-out="+c.generateConfig)
+	}
+
+	for _, vf := range c.varFiles {
+		args = append(args, "-var-file="+vf)
+	}
+
+	if c.vars != nil {
+		for _, v := range c.vars {
+			args = append(args, "-var", v)
+		}
+	}
+
+	return args, nil
+}
+
+func (tf *Terraform) buildQueryCmd(ctx context.Context, c queryConfig, args []string) (*exec.Cmd, error) {
+	// optional positional argument
+	if c.dir != "" {
+		args = append(args, c.dir)
+	}
+
+	mergeEnv := map[string]string{}
+	if c.reattachInfo != nil {
+		reattachStr, err := c.reattachInfo.marshalString()
+		if err != nil {
+			return nil, err
+		}
+		mergeEnv[reattachEnvVar] = reattachStr
+	}
+
+	return tf.buildTerraformCmd(ctx, mergeEnv, args...), nil
+}

--- a/tfexec/query.go
+++ b/tfexec/query.go
@@ -6,7 +6,7 @@ package tfexec
 import (
 	"context"
 	"fmt"
-	"io"
+	"iter"
 	"os/exec"
 )
 
@@ -57,25 +57,18 @@ func (opt *VarOption) configureQuery(conf *queryConfig) {
 //
 // QueryJSON is likely to be removed in a future major version in favour of
 // query returning JSON by default.
-func (tf *Terraform) QueryJSON(ctx context.Context, w io.Writer, opts ...QueryOption) error {
+func (tf *Terraform) QueryJSON(ctx context.Context, opts ...QueryOption) (iter.Seq[NextMessage], error) {
 	err := tf.compatible(ctx, tf1_14_0, nil)
 	if err != nil {
-		return fmt.Errorf("terraform query -json was added in 1.14.0: %w", err)
+		return nil, fmt.Errorf("terraform query -json was added in 1.14.0: %w", err)
 	}
 
-	tf.SetStdout(w)
-
-	cmd, err := tf.queryJSONCmd(ctx, opts...)
+	queryCmd, err := tf.queryJSONCmd(ctx, opts...)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	err = tf.runTerraformCmd(ctx, cmd)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return tf.runTerraformCmdJSONLog(ctx, queryCmd), nil
 }
 
 func (tf *Terraform) queryJSONCmd(ctx context.Context, opts ...QueryOption) (*exec.Cmd, error) {

--- a/tfexec/query_test.go
+++ b/tfexec/query_test.go
@@ -1,0 +1,59 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package tfexec
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-exec/tfexec/internal/testutil"
+)
+
+func TestQueryJSONCmd(t *testing.T) {
+	td := t.TempDir()
+
+	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest_Alpha_v1_14))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// empty env, to avoid environ mismatch in testing
+	tf.SetEnv(map[string]string{})
+
+	t.Run("defaults", func(t *testing.T) {
+		queryCmd, err := tf.queryJSONCmd(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assertCmd(t, []string{
+			"query",
+			"-no-color",
+			"-json",
+		}, nil, queryCmd)
+	})
+
+	t.Run("override all", func(t *testing.T) {
+		queryCmd, err := tf.queryJSONCmd(context.Background(),
+			GenerateConfigOut("generated.tf"),
+			Var("android=paranoid"),
+			Var("brain_size=planet"),
+			VarFile("trillian"),
+			Dir("earth"))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assertCmd(t, []string{
+			"query",
+			"-no-color",
+			"-generate-config-out=generated.tf",
+			"-var-file=trillian",
+			"-var", "android=paranoid",
+			"-var", "brain_size=planet",
+			"-json",
+			"earth",
+		}, nil, queryCmd)
+	})
+}

--- a/tfexec/version.go
+++ b/tfexec/version.go
@@ -34,6 +34,8 @@ var (
 	tf1_4_0  = version.Must(version.NewVersion("1.4.0"))
 	tf1_6_0  = version.Must(version.NewVersion("1.6.0"))
 	tf1_9_0  = version.Must(version.NewVersion("1.9.0"))
+	tf1_13_0 = version.Must(version.NewVersion("1.13.0"))
+	tf1_14_0 = version.Must(version.NewVersion("1.14.0"))
 )
 
 // Version returns structured output from the terraform version command including both the Terraform CLI version


### PR DESCRIPTION
## Description

This PR adds a new internal method that allows easier consumption of Terraform's structured log format. It exposes log messages as an iterator via `iter.Seq[NextMessage]`.

`QueryJSON` is the first command that makes use of new the method.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
