### PR TITLE
go.mod: Keep compatibility constraint separate from build

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,9 @@
 module github.com/hashicorp/terraform-exec
 
-go 1.25.8
+// Keep last digit at zero, use toolchain for Go build requirement
+go 1.25.0
+
+toolchain go1.25.8
 
 require (
 	github.com/google/go-cmp v0.7.0


### PR DESCRIPTION
The PATCH digit - i.e. the last of the three numbers ([confusingly called "minor revisions" by Go naming convention](https://go.dev/doc/devel/release)) bumps in Go version usually represent _security_ fixes and should almost never imply breaking changes so as it require us to declare such changes a _compatibility_ constraint (which is what `go` directive does in `go.mod`).

`terraform-exec` is only used as a library and we do not produce any binaries. However, we frequently need to deal with noise from noisy security scanners which insist on bumping Go version because of some vulnerability which does not impact this project.

In case of such bumps, especially when the CVEs do not impact this project (practically all past cases) we want to avoid unintended side effect of imposing the new Go version on downstream consumers. If downstream is so concerned or has to deal with similarly noisy scanners they can pin Go version in their own project.

Therefore, we'll use the `toolchain` directive exclusively for bumping Go due to CVE discoveries based on the (yet unconfirmed but hopeful) assumption that the scanners care about build-time version rather than compatibility constraint.

The comment should ensure this knowledge survives future Go bumps even when/if `go mod tidy` decides to wipe the `toolchain` directive.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
