### PR TITLE
Inherit a set of allowlisted environment variables of the process environment

### DIFF
--- a/tfexec/cmd.go
+++ b/tfexec/cmd.go
@@ -123,6 +123,64 @@ func envSlice(environ map[string]string) []string {
 	return env
 }
 
+// exact variable names that are safe to inherit from the calling process.
+// anything not listed here or matched by inheritedEnvPrefixAllowlist is
+// excluded; callers may pass additional variables explicitly via SetEnv.
+var inheritedEnvAllowlist = map[string]bool{
+	"HOME":           true,
+	"PATH":           true,
+	"USER":           true,
+	"LOGNAME":        true,
+	"TMPDIR":         true,
+	"TEMP":           true,
+	"TMP":            true,
+	"SSL_CERT_FILE":  true,
+	"SSL_CERT_DIR":   true,
+	"CURL_CA_BUNDLE": true,
+	"HTTP_PROXY":     true,
+	"HTTPS_PROXY":    true,
+	"NO_PROXY":       true,
+	"http_proxy":     true,
+	"https_proxy":    true,
+	"no_proxy":       true,
+}
+
+// prefixes of cloud-provider authentication variable families that are safe
+// to inherit. these are commonly injected by platform IAM mechanisms (IRSA,
+// Workload Identity, Managed Identity) and consumed directly by providers.
+var inheritedEnvPrefixAllowlist = []string{
+	"AWS_",
+	"GOOGLE_",
+	"GCLOUD_",
+	"CLOUDSDK_",
+	"ARM_",
+	"AZURE_",
+	"VAULT_",
+	"GITHUB_",
+	"MAGOS_",
+}
+
+func safeInheritedEnv() map[string]string {
+	env := make(map[string]string)
+	for _, e := range os.Environ() {
+		k, v, ok := strings.Cut(e, "=")
+		if !ok {
+			continue
+		}
+		if inheritedEnvAllowlist[k] {
+			env[k] = v
+			continue
+		}
+		for _, prefix := range inheritedEnvPrefixAllowlist {
+			if strings.HasPrefix(k, prefix) {
+				env[k] = v
+				break
+			}
+		}
+	}
+	return env
+}
+
 // buildEnv determines which environment variables should affect use of a Terraform
 // executable.
 //
@@ -134,12 +192,10 @@ func envSlice(environ map[string]string) []string {
 // This method also enforces some rules for the entire terraform-exec library,
 // for example User Agent data set via ENVs.
 func (tf *Terraform) buildEnv(mergeEnv map[string]string) []string {
-	// set Terraform level env, if env is nil, fall back to os.Environ
-	var env map[string]string
-	if tf.env == nil {
-		env = envMap(os.Environ())
-	} else {
-		env = make(map[string]string, len(tf.env))
+	// inherit only the allowlisted subset of the process environment, then
+	// overlay any variables the caller set explicitly via SetEnv
+	env := safeInheritedEnv()
+	if tf.env != nil {
 		maps.Copy(env, tf.env)
 	}
 

--- a/tfexec/cmd_test.go
+++ b/tfexec/cmd_test.go
@@ -5,6 +5,7 @@ package tfexec
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 	"testing"
@@ -49,6 +50,24 @@ func defaultEnv() []string {
 	}
 }
 
+// stripSafeInherited removes variables that safeInheritedEnv pulls in from the
+// test machine's environment. assertCmd calls this on the actual env so that
+// command-level tests can assert on the library-managed vars only, without
+// needing to know which safe-inherited vars happen to be set on the host.
+func stripSafeInherited(env map[string]string) {
+	for k := range inheritedEnvAllowlist {
+		delete(env, k)
+	}
+	for k := range env {
+		for _, prefix := range inheritedEnvPrefixAllowlist {
+			if strings.HasPrefix(k, prefix) {
+				delete(env, k)
+				break
+			}
+		}
+	}
+}
+
 // assertCmd asserts that a constructed exec.Cmd contains the expected args and environment variables.
 // The command itself isn't executed; that is only done in E2E tests.
 func assertCmd(t *testing.T, expectedArgs []string, expectedEnv map[string]string, actual *exec.Cmd) {
@@ -87,6 +106,10 @@ func assertCmd(t *testing.T, expectedArgs []string, expectedEnv map[string]strin
 		}
 	}
 
+	// strip safe-inherited vars from actual: they come from the test machine's
+	// environment and are not what command-level tests are asserting on
+	stripSafeInherited(actualEnv)
+
 	// compare against raw slice len incase of duplication or something
 	if len(expectedEnv) != len(actualEnv) {
 		t.Fatalf("env mismatch\n\nexpected:\n%v\n\ngot:\n%v", envSlice(expectedEnv), actual.Env)
@@ -100,5 +123,147 @@ func assertCmd(t *testing.T, expectedArgs []string, expectedEnv map[string]strin
 		if ev != av {
 			t.Fatalf("env mismatch, expected %q, got %q\n\nfull expected:\n%v\n\nfull actual:\n%v", ev, av, envSlice(expectedEnv), envSlice(actualEnv))
 		}
+	}
+}
+
+func TestSafeInheritedEnvAllowlist(t *testing.T) {
+	for key := range inheritedEnvAllowlist {
+		t.Run(key, func(t *testing.T) {
+			t.Setenv(key, "test-value")
+			env := safeInheritedEnv()
+			if v, ok := env[key]; !ok || v != "test-value" {
+				t.Fatalf("expected allowlisted var %q to be inherited, present=%v value=%q", key, ok, v)
+			}
+		})
+	}
+}
+
+func TestSafeInheritedEnvCloudPrefixes(t *testing.T) {
+	for _, tc := range []struct {
+		key    string
+		reason string
+	}{
+		{"AWS_ACCESS_KEY_ID", "AWS credentials"},
+		{"AWS_SECRET_ACCESS_KEY", "AWS credentials"},
+		{"AWS_SESSION_TOKEN", "AWS credentials"},
+		{"AWS_REGION", "AWS config"},
+		{"GOOGLE_CREDENTIALS", "GCP credentials"},
+		{"GOOGLE_APPLICATION_CREDENTIALS", "GCP service account"},
+		{"GCLOUD_PROJECT", "gcloud config"},
+		{"CLOUDSDK_COMPUTE_ZONE", "Cloud SDK config"},
+		{"ARM_CLIENT_ID", "Azure credentials"},
+		{"ARM_TENANT_ID", "Azure credentials"},
+		{"AZURE_CLIENT_SECRET", "Azure credentials"},
+		{"VAULT_ADDR", "Vault config"},
+		{"VAULT_TOKEN", "Vault credentials"},
+		{"GITHUB_TOKEN", "GitHub provider"},
+	} {
+		t.Run(tc.key, func(t *testing.T) {
+			t.Setenv(tc.key, "test-value")
+			env := safeInheritedEnv()
+			if v, ok := env[tc.key]; !ok || v != "test-value" {
+				t.Fatalf("expected cloud provider var %q (%s) to be inherited, present=%v value=%q", tc.key, tc.reason, ok, v)
+			}
+		})
+	}
+}
+
+func TestSafeInheritedEnvBlocksDangerousVars(t *testing.T) {
+	for _, tc := range []struct {
+		key    string
+		reason string
+	}{
+		{"LD_PRELOAD", "dynamic linker injection"},
+		{"LD_LIBRARY_PATH", "dynamic linker injection"},
+		{"DYLD_INSERT_LIBRARIES", "macOS dynamic linker injection"},
+		{"DYLD_LIBRARY_PATH", "macOS dynamic linker injection"},
+		{"TF_CLI_CONFIG_FILE", "redirect terraform config"},
+		{"TF_PLUGIN_DIR", "redirect provider lookup"},
+		{"TF_DATA_DIR", "redirect .terraform directory"},
+		{"TERRAFORMRC", "redirect terraform config"},
+		{"BASH_ENV", "bash code injection via subshells"},
+		{"ENV", "POSIX shell code injection"},
+		{"TF_LOG", "managed by library, not user-injectable"},
+		{"TF_WORKSPACE", "managed by library, not user-injectable"},
+		{"TF_INPUT", "managed by library, not user-injectable"},
+	} {
+		t.Run(tc.key, func(t *testing.T) {
+			t.Setenv(tc.key, "malicious-value")
+			env := safeInheritedEnv()
+			if v, ok := env[tc.key]; ok {
+				t.Fatalf("expected dangerous var %q (%s) to be blocked, but it was inherited with value %q", tc.key, tc.reason, v)
+			}
+		})
+	}
+}
+
+func TestSafeInheritedEnvSetEnvCanPassAnything(t *testing.T) {
+	// SetEnv must be able to pass non-allowlisted vars explicitly — callers
+	// need an escape hatch for providers not covered by the allowlist.
+	td := t.TempDir()
+	tf, err := NewTerraform(td, "echo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = tf.SetEnv(map[string]string{
+		"KUBECONFIG":    "/tmp/kubeconfig",
+		"MY_CUSTOM_VAR": "custom-value",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := tf.buildTerraformCmd(t.Context(), nil)
+	env := envMap(cmd.Env)
+
+	for k, want := range map[string]string{
+		"KUBECONFIG":    "/tmp/kubeconfig",
+		"MY_CUSTOM_VAR": "custom-value",
+	} {
+		if got := env[k]; got != want {
+			t.Fatalf("expected SetEnv var %q=%q in cmd env, got %q", k, want, got)
+		}
+	}
+}
+
+func TestSafeInheritedEnvEmptyValue(t *testing.T) {
+	// an allowlisted var set to empty string should still pass through
+	t.Setenv("HOME", "")
+	env := safeInheritedEnv()
+	if _, ok := env["HOME"]; !ok {
+		t.Fatal("expected HOME with empty value to be inherited")
+	}
+}
+
+func TestSafeInheritedEnvDangerousVarNotInheritedEvenIfPrefixMatches(t *testing.T) {
+	// GOOGLE_* prefix is allowed, but a hypothetical GOOGLE_INTERNAL_OVERRIDE
+	// that slipped in should only reach Terraform if the caller sets it via
+	// SetEnv — not by accident from the ambient environment.
+	// This test documents the accepted risk: we inherit all GOOGLE_* vars.
+	// The allowlisted prefixes are intentionally broad for IAM compatibility.
+	t.Setenv("AWS_ANYTHING", "value")
+	env := safeInheritedEnv()
+	if _, ok := env["AWS_ANYTHING"]; !ok {
+		// expected: prefix-matched vars do pass through
+		t.Fatal("AWS_ANYTHING should be inherited via AWS_ prefix")
+	}
+
+	// contrast: a non-matching var must not pass through
+	t.Setenv("RANDOM_SECRET", "secret")
+	env = safeInheritedEnv()
+	if _, ok := env["RANDOM_SECRET"]; ok {
+		t.Fatal("RANDOM_SECRET must not be inherited")
+	}
+}
+
+func TestSafeInheritedEnvHomePresent(t *testing.T) {
+	// HOME must always be inherited
+	home := os.Getenv("HOME")
+	if home == "" {
+		t.Skip("HOME not set in this environment")
+	}
+	env := safeInheritedEnv()
+	if env["HOME"] != home {
+		t.Fatalf("expected HOME=%q, got %q", home, env["HOME"])
 	}
 }


### PR DESCRIPTION
Previously, `buildEnv` behaved inconsistently: when `SetEnv` was not called, the full `os.Environ()` was inherited; when `SetEnv` was called, the subprocess received only the explicitly provided vars, stripping `HOME`, `PATH`, and everything else. This caused Terraform to fall back to [getent](https://man7.org/linux/man-pages/man1/getent.1.html) for home-directory resolution, which fails in minimal container images that do not have `$HOME` set.

Additional environment variables may be supplied via `SetEnv`.