### PR TITLE
Add support for `workspace list -json`

### DIFF
--- a/tfexec/cmd.go
+++ b/tfexec/cmd.go
@@ -210,6 +210,8 @@ func (tf *Terraform) buildTerraformCmd(ctx context.Context, mergeEnv map[string]
 	return cmd
 }
 
+// runTerraformCmdJSON runs a given command that produces a single, static JSON output.
+// This is decoded into the provided v argument.
 func (tf *Terraform) runTerraformCmdJSON(ctx context.Context, cmd *exec.Cmd, v interface{}) error {
 	var outbuf = bytes.Buffer{}
 	cmd.Stdout = mergeWriters(cmd.Stdout, &outbuf)
@@ -224,6 +226,8 @@ func (tf *Terraform) runTerraformCmdJSON(ctx context.Context, cmd *exec.Cmd, v i
 	return dec.Decode(v)
 }
 
+// runTerraformCmdJSONLog runs a given command that produces multiple, structured JSON log messages.
+// Due to this it returns an iterator that allows calling code to consume a stream of messages.
 func (tf *Terraform) runTerraformCmdJSONLog(ctx context.Context, cmd *exec.Cmd) iter.Seq[NextMessage] {
 	pr, pw := io.Pipe()
 	tf.SetStdout(pw)

--- a/tfexec/internal/e2etest/workspace_test.go
+++ b/tfexec/internal/e2etest/workspace_test.go
@@ -5,15 +5,39 @@ package e2etest
 
 import (
 	"context"
+	"io"
 	"reflect"
 	"testing"
 
 	"github.com/hashicorp/go-version"
+	tfjson "github.com/hashicorp/terraform-json"
 
 	"github.com/hashicorp/terraform-exec/tfexec"
+	"github.com/hashicorp/terraform-exec/tfexec/internal/testutil"
 )
 
 const defaultWorkspace = "default"
+
+func makeWorkspaceListOutput(current string, workspaces ...string) tfjson.WorkspaceListOutput {
+	output := tfjson.WorkspaceListOutput{
+		FormatVersion: "1.0.0",
+		Diagnostics:   []tfjson.Diagnostic{},
+	}
+
+	// Allow empty results
+	if current == "" {
+		return output
+	}
+
+	for _, ws := range workspaces {
+		entry := tfjson.WorkspaceListEntry{
+			Name:      ws,
+			IsCurrent: ws == current,
+		}
+		output.Workspaces = append(output.Workspaces, entry)
+	}
+	return output
+}
 
 func TestWorkspace_default_only(t *testing.T) {
 	runTest(t, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
@@ -139,6 +163,22 @@ func TestWorkspace_deletion(t *testing.T) {
 	})
 }
 
+func TestWorkspace_listJSON(t *testing.T) {
+	runTestWithVersions(t, []string{testutil.Latest_v1_16}, "workspace-list-json", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
+		// List no workspaces when none exist
+		assertWorkspaceListJSON(t, tf, makeWorkspaceListOutput(""))
+
+		// Create a workspace
+		newWorkspace := "new-workspace"
+		err := tf.WorkspaceNew(context.Background(), newWorkspace)
+		if err != nil {
+			t.Fatalf("got error creating new workspace: %s", err)
+		}
+
+		assertWorkspaceListJSON(t, tf, makeWorkspaceListOutput(newWorkspace, newWorkspace))
+	})
+}
+
 func assertWorkspaceList(t *testing.T, tf *tfexec.Terraform, expectedCurrent string, expectedWorkspaces ...string) {
 	actualWorkspaces, actualCurrent, err := tf.WorkspaceList(context.Background())
 	if err != nil {
@@ -150,6 +190,22 @@ func assertWorkspaceList(t *testing.T, tf *tfexec.Terraform, expectedCurrent str
 	expectedWorkspaces = append([]string{defaultWorkspace}, expectedWorkspaces...)
 	if !reflect.DeepEqual(actualWorkspaces, expectedWorkspaces) {
 		t.Fatalf("expected %#v, got %#v", actualWorkspaces, expectedWorkspaces)
+	}
+}
+
+func assertWorkspaceListJSON(t *testing.T, tf *tfexec.Terraform, expected tfjson.WorkspaceListOutput) {
+	w := io.Discard
+	output, err := tf.WorkspaceListJSON(context.Background(), w)
+	if err != nil {
+		t.Fatalf("got error querying workspace list: %s", err)
+	}
+	expectedCurrent := expected.CurrentWorkspace().Name
+	if output.CurrentWorkspace().Name != expectedCurrent {
+		t.Fatalf("expected %q workspace to be selected, got %q", expectedCurrent, output.CurrentWorkspace().Name)
+	}
+
+	if !reflect.DeepEqual(*output, expected) {
+		t.Fatalf("expected %#v, got %#v", expected, output)
 	}
 }
 

--- a/tfexec/internal/testutil/tfcache.go
+++ b/tfexec/internal/testutil/tfcache.go
@@ -38,8 +38,10 @@ const (
 	Latest_v1_11       = "1.11.4"
 	Latest_v1_12       = "1.12.2"
 	Latest_Alpha_v1_14 = "1.14.0-alpha20250903"
+	Latest_v1_15       = "1.15.1"
+	Latest_v1_16       = "1.16.0"
 
-	Latest_v1 = "1.14.0"
+	Latest_v1 = "1.16.1"
 )
 
 const appendUserAgent = "tfexec-testutil"

--- a/tfexec/internal/testutil/tfcache.go
+++ b/tfexec/internal/testutil/tfcache.go
@@ -38,7 +38,7 @@ const (
 	Latest_v1_11       = "1.11.4"
 	Latest_v1_12       = "1.12.2"
 	Latest_Alpha_v1_14 = "1.14.0-alpha20250903"
-	Latest_v1_15       = "1.15.1"
+	Latest_v1_15       = "1.15.8"
 	Latest_v1_16       = "1.16.0"
 
 	Latest_v1 = "1.16.1"

--- a/tfexec/internal/testutil/tfcache.go
+++ b/tfexec/internal/testutil/tfcache.go
@@ -41,7 +41,7 @@ const (
 	Latest_v1_15       = "1.15.8"
 	Latest_v1_16       = "1.16.0"
 
-	Latest_v1 = "1.16.1"
+	Latest_v1 = "1.15.8"
 )
 
 const appendUserAgent = "tfexec-testutil"

--- a/tfexec/version.go
+++ b/tfexec/version.go
@@ -39,6 +39,7 @@ var (
 	tf1_10_0 = version.Must(version.NewVersion("1.10.0"))
 	tf1_13_0 = version.Must(version.NewVersion("1.13.0"))
 	tf1_14_0 = version.Must(version.NewVersion("1.14.0"))
+	tf1_16_0 = version.Must(version.NewVersion("1.16.0"))
 )
 
 // Version returns structured output from the terraform version command including both the Terraform CLI version

--- a/tfexec/workspace_list.go
+++ b/tfexec/workspace_list.go
@@ -38,12 +38,11 @@ func (tf *Terraform) WorkspaceList(ctx context.Context, opts ...WorkspaceListOpt
 		return nil, "", err
 	}
 
-	ws, current := parseWorkspaceList(outBuf.String())
+	// Parse human output into a list of workspaces and the current workspace
+	ws, current := parseWorkspaceListHumanOutput(outBuf.String())
 
 	return ws, current, nil
 }
-
-const currentWorkspacePrefix = "* "
 
 func (tf *Terraform) workspaceListCmd(ctx context.Context, opts ...WorkspaceListOption) (*exec.Cmd, error) {
 	c := defaultWorkspaceListOptions
@@ -52,19 +51,15 @@ func (tf *Terraform) workspaceListCmd(ctx context.Context, opts ...WorkspaceList
 		o.configureWorkspaceList(&c)
 	}
 
-	mergeEnv := map[string]string{}
-	if c.reattachInfo != nil {
-		reattachStr, err := c.reattachInfo.marshalString()
-		if err != nil {
-			return nil, err
-		}
-		mergeEnv[reattachEnvVar] = reattachStr
-	}
-
-	return tf.buildTerraformCmd(ctx, mergeEnv, "workspace", "list", "-no-color"), nil
+	args := []string{"workspace", "list", "-no-color"}
+	return tf.buildWorkspaceListCmd(ctx, c, args)
 }
 
-func parseWorkspaceList(stdout string) ([]string, string) {
+// parseWorkspaceListHumanOutput parses human output from the workspace list command
+// to return a slice of workspace names and the current workspace name
+func parseWorkspaceListHumanOutput(stdout string) ([]string, string) {
+	var currentWorkspacePrefix string = "* "
+
 	lines := strings.Split(stdout, "\n")
 
 	current := ""
@@ -82,4 +77,17 @@ func parseWorkspaceList(stdout string) ([]string, string) {
 	}
 
 	return workspaces, current
+}
+
+func (tf *Terraform) buildWorkspaceListCmd(ctx context.Context, c workspaceListConfig, args []string) (*exec.Cmd, error) {
+	mergeEnv := map[string]string{}
+	if c.reattachInfo != nil {
+		reattachStr, err := c.reattachInfo.marshalString()
+		if err != nil {
+			return nil, err
+		}
+		mergeEnv[reattachEnvVar] = reattachStr
+	}
+
+	return tf.buildTerraformCmd(ctx, mergeEnv, args...), nil
 }

--- a/tfexec/workspace_list.go
+++ b/tfexec/workspace_list.go
@@ -5,8 +5,12 @@ package tfexec
 
 import (
 	"context"
+	"fmt"
+	"io"
 	"os/exec"
 	"strings"
+
+	tfjson "github.com/hashicorp/terraform-json"
 )
 
 type workspaceListConfig struct {
@@ -77,6 +81,54 @@ func parseWorkspaceListHumanOutput(stdout string) ([]string, string) {
 	}
 
 	return workspaces, current
+}
+
+// WorkspaceListJSON represents the terraform workspace list subcommand with the `-json` flag.
+// Using the `-json` flag will result in
+// [machine-readable](https://developer.hashicorp.com/terraform/internals/machine-readable-ui)
+// JSON being written to the supplied `io.Writer`. WorkspaceListJSON is likely to be
+// removed in a future major version in favour of WorkspaceList returning JSON by default.
+func (tf *Terraform) WorkspaceListJSON(ctx context.Context, w io.Writer, opts ...WorkspaceListOption) (*tfjson.WorkspaceListOutput, error) {
+	err := tf.compatible(ctx, tf1_16_0, nil)
+	if err != nil {
+		return nil, fmt.Errorf("terraform workspace list -json was added in 1.16.0: %w", err)
+	}
+
+	tf.SetStdout(w)
+
+	cmd, err := tf.workspaceListJSONCmd(ctx, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	var output tfjson.WorkspaceListOutput
+
+	err = tf.runTerraformCmdJSON(ctx, cmd, &output)
+	if err != nil {
+		return nil, err
+	}
+
+	return &output, nil
+}
+
+func (tf *Terraform) workspaceListJSONCmd(ctx context.Context, opts ...WorkspaceListOption) (*exec.Cmd, error) {
+	c := defaultWorkspaceListOptions
+
+	for _, o := range opts {
+		o.configureWorkspaceList(&c)
+	}
+
+	mergeEnv := map[string]string{}
+	if c.reattachInfo != nil {
+		reattachStr, err := c.reattachInfo.marshalString()
+		if err != nil {
+			return nil, err
+		}
+		mergeEnv[reattachEnvVar] = reattachStr
+	}
+
+	args := []string{"workspace", "list", "-json"}
+	return tf.buildWorkspaceListCmd(ctx, c, args)
 }
 
 func (tf *Terraform) buildWorkspaceListCmd(ctx context.Context, c workspaceListConfig, args []string) (*exec.Cmd, error) {

--- a/tfexec/workspace_list_test.go
+++ b/tfexec/workspace_list_test.go
@@ -59,7 +59,7 @@ func TestWorkspaceListCmd(t *testing.T) {
 	})
 }
 
-func TestParseWorkspaceList(t *testing.T) {
+func TestParseWorkspaceListHumanOutput(t *testing.T) {
 	for i, c := range []struct {
 		expected        []string
 		expectedCurrent string
@@ -96,7 +96,7 @@ func TestParseWorkspaceList(t *testing.T) {
 		},
 	} {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-			actualList, actualCurrent := parseWorkspaceList(c.stdout)
+			actualList, actualCurrent := parseWorkspaceListHumanOutput(c.stdout)
 
 			if actualCurrent != c.expectedCurrent {
 				t.Fatalf("expected selected %q, got %q", c.expectedCurrent, actualCurrent)

--- a/tfexec/workspace_list_test.go
+++ b/tfexec/workspace_list_test.go
@@ -59,6 +59,53 @@ func TestWorkspaceListCmd(t *testing.T) {
 	})
 }
 
+func TestWorkspaceListCmdJSON(t *testing.T) {
+	tf, err := NewTerraform(t.TempDir(), tfVersion(t, testutil.Latest_v1))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// empty env, to avoid environ mismatch in testing
+	tf.SetEnv(map[string]string{})
+
+	t.Run("defaults", func(t *testing.T) {
+		workspaceListCmd, err := tf.workspaceListJSONCmd(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assertCmd(t, []string{
+			"workspace", "list",
+			"-json",
+		}, nil, workspaceListCmd)
+	})
+
+	t.Run("reattach config", func(t *testing.T) {
+		workspaceListCmd, err := tf.workspaceListJSONCmd(context.Background(), Reattach(map[string]ReattachConfig{
+			"registry.terraform.io/hashicorp/examplecloud": {
+				Protocol:        "grpc",
+				ProtocolVersion: 6,
+				Pid:             1234,
+				Test:            true,
+				Addr: ReattachConfigAddr{
+					Network: "unix",
+					String:  "/fake_folder/T/plugin123",
+				},
+			},
+		}))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assertCmd(t, []string{
+			"workspace", "list",
+			"-json",
+		}, map[string]string{
+			"TF_REATTACH_PROVIDERS": `{"registry.terraform.io/hashicorp/examplecloud":{"Protocol":"grpc","ProtocolVersion":6,"Pid":1234,"Test":true,"Addr":{"Network":"unix","String":"/fake_folder/T/plugin123"}}}`,
+		}, workspaceListCmd)
+	})
+}
+
 func TestParseWorkspaceListHumanOutput(t *testing.T) {
 	for i, c := range []struct {
 		expected        []string


### PR DESCRIPTION
## Related Issue

Follows https://github.com/hashicorp/terraform/pull/38397 and depends on https://github.com/hashicorp/terraform-json/pull/198

This PR is blocked, pending future releases of:
- [ ] Terraform v1.16
- [ ] terraform-json with support for `workspace list -json`

This PR is an incomplete WIP because E2E tests need a v1.16 binary available for download.

## Description

This PR adds the ability to perform a `workspace list -json` command. The new JSON which is expected as part of TF v1.16.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain. **No**
