### PR TITLE
init: Add support for lock file mode

### DIFF
--- a/tfexec/init.go
+++ b/tfexec/init.go
@@ -19,6 +19,7 @@ type initConfig struct {
 	get           bool
 	getPlugins    bool
 	lock          bool
+	lockFileMode  string
 	lockTimeout   string
 	pluginDir     []string
 	reattachInfo  ReattachInfo
@@ -76,6 +77,10 @@ func (opt *LockOption) configureInit(conf *initConfig) {
 	conf.lock = opt.lock
 }
 
+func (opt *LockFileModeOption) configureInit(conf *initConfig) {
+	conf.lockFileMode = opt.mode
+}
+
 func (opt *LockTimeoutOption) configureInit(conf *initConfig) {
 	conf.lockTimeout = opt.timeout
 }
@@ -107,6 +112,11 @@ func (tf *Terraform) configureInitOptions(ctx context.Context, c *initConfig, op
 			err := tf.compatible(ctx, nil, tf0_15_0)
 			if err != nil {
 				return fmt.Errorf("-lock, -lock-timeout, -verify-plugins, and -get-plugins options are no longer available as of Terraform 0.15: %w", err)
+			}
+		case *LockFileModeOption:
+			err := tf.compatible(ctx, tf0_15_0, nil)
+			if err != nil {
+				return fmt.Errorf("terraform init -lockfile was added in 0.15.0: %w", err)
 			}
 		}
 
@@ -194,6 +204,9 @@ func (tf *Terraform) buildInitArgs(ctx context.Context, c initConfig) ([]string,
 	// string opts: only pass if set
 	if c.fromModule != "" {
 		args = append(args, "-from-module="+c.fromModule)
+	}
+	if c.lockFileMode != "" {
+		args = append(args, "-lockfile="+c.lockFileMode)
 	}
 
 	// string opts removed in 0.15: pass if set and <0.15

--- a/tfexec/init_test.go
+++ b/tfexec/init_test.go
@@ -91,6 +91,13 @@ func TestInitCmd_v012(t *testing.T) {
 			"initdir",
 		}, nil, initCmd)
 	})
+
+	t.Run("lock file mode unsupported", func(t *testing.T) {
+		_, err := tf.initCmd(context.Background(), LockFileMode("readonly"))
+		if err == nil {
+			t.Fatal("expected an error for -lockfile with Terraform 0.12")
+		}
+	})
 }
 
 func TestInitCmd_v1(t *testing.T) {
@@ -125,6 +132,7 @@ func TestInitCmd_v1(t *testing.T) {
 		initCmd, err := tf.initCmd(
 			context.Background(),
 			FromModule("testsource"),
+			LockFileMode("readonly"),
 			Backend(false),
 			Get(false),
 			Upgrade(true),
@@ -145,6 +153,7 @@ func TestInitCmd_v1(t *testing.T) {
 			"-no-color",
 			"-input=false",
 			"-from-module=testsource",
+			"-lockfile=readonly",
 			"-backend=false",
 			"-get=false",
 			"-upgrade=true",
@@ -192,6 +201,7 @@ func TestInitJSONCmd(t *testing.T) {
 		initCmd, err := tf.initJSONCmd(
 			context.Background(),
 			FromModule("testsource"),
+			LockFileMode("readonly"),
 			Backend(false),
 			Get(false),
 			Upgrade(true),
@@ -212,6 +222,7 @@ func TestInitJSONCmd(t *testing.T) {
 			"-no-color",
 			"-input=false",
 			"-from-module=testsource",
+			"-lockfile=readonly",
 			"-backend=false",
 			"-get=false",
 			"-upgrade=true",

--- a/tfexec/internal/e2etest/init_test.go
+++ b/tfexec/internal/e2etest/init_test.go
@@ -15,11 +15,22 @@ import (
 	"github.com/hashicorp/terraform-exec/tfexec/internal/testutil"
 )
 
+var initLockFileModeMinVersion = version.Must(version.NewVersion("0.15.0"))
+
 func TestInit(t *testing.T) {
 	runTest(t, "basic", func(t *testing.T, tfv *version.Version, tf *tfexec.Terraform) {
 		err := tf.Init(context.Background())
 		if err != nil {
 			t.Fatalf("error running Init in test directory: %s", err)
+		}
+
+		if tfv.LessThan(initLockFileModeMinVersion) {
+			return
+		}
+
+		err = tf.Init(context.Background(), tfexec.LockFileMode("readonly"))
+		if err != nil {
+			t.Fatalf("error running Init with a read-only lock file: %s", err)
 		}
 	})
 }

--- a/tfexec/options.go
+++ b/tfexec/options.go
@@ -476,3 +476,14 @@ type LockFileOption struct {
 func LockFile(useLockFile bool) *LockFileOption {
 	return &LockFileOption{useLockFile: useLockFile}
 }
+
+// LockFileModeOption represents the -lockfile flag for terraform init.
+type LockFileModeOption struct {
+	mode string
+}
+
+// LockFileMode sets the dependency lock file mode for terraform init.
+// Terraform currently accepts only "readonly", which conflicts with Upgrade(true).
+func LockFileMode(mode string) *LockFileModeOption {
+	return &LockFileModeOption{mode: mode}
+}


### PR DESCRIPTION
## Summary

- Expose `terraform init -lockfile=MODE` through a new `LockFileMode` option.
- Reject the option for Terraform versions before 0.15.0, when the flag was introduced.
- Cover command construction, the unsupported version boundary, and a real `readonly` initialization.

Closes #602.

## Testing

- `go vet ./...`
- `go test -race $(go list ./... | rg -v /tfexec/internal/e2etest$)`
- `TFEXEC_E2ETEST_TERRAFORM_PATH=<terraform-1.15.8> go test -race -timeout=10m -v ./tfexec/internal/e2etest -run ^TestInit$`