### PR TITLE
tfexec: Add `-minimal-refresh` flag to plan command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.26.0 (Unreleased)
+
+ENHANCEMENTS:
+- tfexec: Add `-minimal-refresh` to `(Terraform).Plan()` method ([#607](https://github.com/hashicorp/terraform-exec/pull/607))
+
 # 0.25.3 (August 17, 2026)
 
 DEPENDENCIES:

--- a/tfexec/internal/testutil/tfcache.go
+++ b/tfexec/internal/testutil/tfcache.go
@@ -38,6 +38,7 @@ const (
 	Latest_v1_11       = "1.11.4"
 	Latest_v1_12       = "1.12.2"
 	Latest_Alpha_v1_14 = "1.14.0-alpha20250903"
+	Latest_v1_17       = "1.17.0-alpha20260827"
 
 	Latest_v1 = "1.14.0"
 )

--- a/tfexec/options.go
+++ b/tfexec/options.go
@@ -373,6 +373,14 @@ func RefreshOnly(refreshOnly bool) *RefreshOnlyOption {
 	return &RefreshOnlyOption{refreshOnly}
 }
 
+type MinimalRefreshOption struct {
+	minimalRefresh bool
+}
+
+func MinimalRefresh(minimalRefresh bool) *MinimalRefreshOption {
+	return &MinimalRefreshOption{minimalRefresh}
+}
+
 type ReplaceOption struct {
 	address string
 }

--- a/tfexec/plan.go
+++ b/tfexec/plan.go
@@ -22,6 +22,7 @@ type planConfig struct {
 	parallelism       int
 	reattachInfo      ReattachInfo
 	refresh           bool
+	minimalRefresh    bool
 	refreshOnly       bool
 	replaceAddrs      []string
 	state             string
@@ -105,6 +106,10 @@ func (opt *AllowDeferralOption) configurePlan(conf *planConfig) {
 
 func (opt *GenerateConfigOutOption) configurePlan(conf *planConfig) {
 	conf.generateConfigOut = opt.path
+}
+
+func (opt *MinimalRefreshOption) configurePlan(conf *planConfig) {
+	conf.minimalRefresh = opt.minimalRefresh
 }
 
 // Plan executes `terraform plan` with the specified options and waits for it
@@ -274,6 +279,23 @@ func (tf *Terraform) buildPlanArgs(ctx context.Context, c planConfig) ([]string,
 		}
 
 		args = append(args, "-allow-deferral")
+	}
+
+	if c.minimalRefresh {
+		err := tf.compatible(ctx, tf1_17_0, nil)
+		if err != nil {
+			return nil, fmt.Errorf("minimal-refresh option was introduced in Terraform 1.17.0: %w", err)
+		}
+		if !c.refresh {
+			return nil, fmt.Errorf("you cannot use refresh=false with mimimal-refresh as they are mutually exclusive")
+		}
+		if c.refreshOnly {
+			return nil, fmt.Errorf("you cannot use refresh-only with mimimal-refresh as minimal-refresh is only valid in normal planning modes")
+		}
+		if c.destroy {
+			return nil, fmt.Errorf("you cannot use destroy with mimimal-refresh as minimal-refresh is only valid in normal planning modes")
+		}
+		args = append(args, "-minimal-refresh")
 	}
 
 	return args, nil

--- a/tfexec/plan_test.go
+++ b/tfexec/plan_test.go
@@ -5,6 +5,7 @@ package tfexec
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-exec/tfexec/internal/testutil"
@@ -246,5 +247,89 @@ func TestPlanCmd_AllowDeferral(t *testing.T) {
 			"-refresh=true",
 			"-allow-deferral",
 		}, nil, planCmd)
+	})
+}
+
+func TestPlanCmd_MinimalRefresh(t *testing.T) {
+	td := t.TempDir()
+
+	tf, err := NewTerraform(td, tfVersion(t, testutil.Latest_v1_17))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// empty env, to avoid environ mismatch in testing
+	tf.SetEnv(map[string]string{})
+
+	t.Run("minimal-refresh plan", func(t *testing.T) {
+		planCmd, err := tf.planCmd(context.Background(), MinimalRefresh(true))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assertCmd(t, []string{
+			"plan",
+			"-no-color",
+			"-input=false",
+			"-detailed-exitcode",
+			"-lock-timeout=0s",
+			"-lock=true",
+			"-parallelism=10",
+			"-refresh=true",
+			"-minimal-refresh",
+		}, nil, planCmd)
+	})
+
+	t.Run("minimal-refresh unsupported version", func(t *testing.T) {
+		tf, err := NewTerraform(td, tfVersion(t, "1.16.0"))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		_, err = tf.planCmd(context.Background(), MinimalRefresh(true))
+		if err == nil {
+			t.Fatal("expected an error but received none")
+		}
+
+		expectedErr := "minimal-refresh option was introduced in Terraform 1.17.0"
+		if !strings.Contains(err.Error(), expectedErr) {
+			t.Fatalf("expected error to contain %q, got: %q", expectedErr, err)
+		}
+	})
+
+	t.Run("minimal-refresh and refresh=false returns an error", func(t *testing.T) {
+		_, err := tf.planCmd(context.Background(), Refresh(false), MinimalRefresh(true))
+		if err == nil {
+			t.Fatal("expected an error but received none")
+		}
+
+		expectedErr := "cannot use refresh=false with mimimal-refresh"
+		if !strings.Contains(err.Error(), expectedErr) {
+			t.Fatalf("expected error to contain %q, got: %q", expectedErr, err)
+		}
+	})
+
+	t.Run("minimal-refresh and refresh-only returns an error", func(t *testing.T) {
+		_, err := tf.planCmd(context.Background(), RefreshOnly(true), MinimalRefresh(true))
+		if err == nil {
+			t.Fatal("expected an error but received none")
+		}
+
+		expectedErr := "cannot use refresh-only with mimimal-refresh"
+		if !strings.Contains(err.Error(), expectedErr) {
+			t.Fatalf("expected error to contain %q, got: %q", expectedErr, err)
+		}
+	})
+
+	t.Run("minimal-refresh and destroy returns an error", func(t *testing.T) {
+		_, err := tf.planCmd(context.Background(), Destroy(true), MinimalRefresh(true))
+		if err == nil {
+			t.Fatal("expected an error but received none")
+		}
+
+		expectedErr := "cannot use destroy with mimimal-refresh"
+		if !strings.Contains(err.Error(), expectedErr) {
+			t.Fatalf("expected error to contain %q, got: %q", expectedErr, err)
+		}
 	})
 }

--- a/tfexec/version.go
+++ b/tfexec/version.go
@@ -22,7 +22,6 @@ var (
 	tf0_6_13 = version.Must(version.NewVersion("0.6.13"))
 	tf0_7_7  = version.Must(version.NewVersion("0.7.7"))
 	tf0_8_0  = version.Must(version.NewVersion("0.8.0"))
-	tf0_9_2  = version.Must(version.NewVersion("0.9.2"))
 	tf0_10_0 = version.Must(version.NewVersion("0.10.0"))
 	tf0_12_0 = version.Must(version.NewVersion("0.12.0"))
 	tf0_13_0 = version.Must(version.NewVersion("0.13.0"))
@@ -31,14 +30,13 @@ var (
 	tf0_15_2 = version.Must(version.NewVersion("0.15.2"))
 	tf0_15_3 = version.Must(version.NewVersion("0.15.3"))
 	tf0_15_4 = version.Must(version.NewVersion("0.15.4"))
-	tf1_1_0  = version.Must(version.NewVersion("1.1.0"))
 	tf1_4_0  = version.Must(version.NewVersion("1.4.0"))
 	tf1_5_0  = version.Must(version.NewVersion("1.5.0"))
 	tf1_6_0  = version.Must(version.NewVersion("1.6.0"))
 	tf1_9_0  = version.Must(version.NewVersion("1.9.0"))
 	tf1_10_0 = version.Must(version.NewVersion("1.10.0"))
-	tf1_13_0 = version.Must(version.NewVersion("1.13.0"))
 	tf1_14_0 = version.Must(version.NewVersion("1.14.0"))
+	tf1_17_0 = version.Must(version.NewVersion("1.17.0"))
 )
 
 // Version returns structured output from the terraform version command including both the Terraform CLI version


### PR DESCRIPTION
> Leaving in draft until Terraform v1.17 is released (or at least when the release branch is created)

## Related Issue

Rel: https://github.com/hashicorp/terraform/pull/38953

## Description

This PR introduces the `-minimal-refresh` flag to the plan command. It's not valid for `terraform refresh` or `terraform destroy`, so no changes there. Added validation to the plan arguments to ensure there aren't any other invalid combinations that would be rejected by TF core 👍🏻 

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

No
